### PR TITLE
Fix instructor availability check and clean up exception handlers

### DIFF
--- a/src/routes/instrutor.py
+++ b/src/routes/instrutor.py
@@ -232,7 +232,9 @@ def verificar_disponibilidade_instrutor(id):
         dia_semana = dias[data_verificacao.weekday()]
         
         # Verifica disponibilidade geral do instrutor
-        disponivel_horario = instrutor.is_disponivel_horario(dia_semana, horario_str)
+        # Usa o horário formatado para garantir comparação correta
+        horario_formatado = horario.strftime('%H:%M')
+        disponivel_horario = instrutor.is_disponivel_horario(dia_semana, horario_formatado)
         
         # Verifica se há ocupações conflitantes
         ocupacoes_dia = Ocupacao.query.filter(
@@ -255,7 +257,7 @@ def verificar_disponibilidade_instrutor(id):
             'conflitos': conflitos
         })
         
-    except ValueError as e:
+    except ValueError:
         return jsonify({'erro': 'Formato de data ou horário inválido'}), 400
     except Exception as e:
         return jsonify({'erro': str(e)}), 500

--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -190,7 +190,7 @@ def criar_ocupacao():
         
         return jsonify(nova_ocupacao.to_dict()), 201
         
-    except ValueError as e:
+    except ValueError:
         return jsonify({'erro': 'Formato de data ou horário inválido'}), 400
     except Exception as e:
         db.session.rollback()
@@ -285,7 +285,7 @@ def atualizar_ocupacao(id):
         db.session.commit()
         return jsonify(ocupacao.to_dict())
         
-    except ValueError as e:
+    except ValueError:
         return jsonify({'erro': 'Formato de data ou horário inválido'}), 400
     except Exception as e:
         db.session.rollback()
@@ -367,7 +367,7 @@ def verificar_disponibilidade():
             'conflitos': conflitos
         })
         
-    except ValueError as e:
+    except ValueError:
         return jsonify({'erro': 'Formato de data ou horário inválido'}), 400
     except Exception as e:
         return jsonify({'erro': str(e)}), 500

--- a/src/routes/sala.py
+++ b/src/routes/sala.py
@@ -244,7 +244,7 @@ def verificar_disponibilidade_sala(id):
             'conflitos': conflitos
         })
         
-    except ValueError as e:
+    except ValueError:
         return jsonify({'erro': 'Formato de data ou horário inválido'}), 400
     except Exception as e:
         return jsonify({'erro': str(e)}), 500


### PR DESCRIPTION
## Summary
- ensure formatted time string when checking instructor availability
- remove unused exception variables across routes

## Testing
- `flake8 src`

------
https://chatgpt.com/codex/tasks/task_e_68477276969c83238dec228b1e131314