### PR TITLE
Add getToken utility and refactor token usage

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -59,8 +59,12 @@ function realizarLogout() {
  * Verifica se o usuário está autenticado
  * @returns {boolean} - True se autenticado, false caso contrário
  */
+function getToken() {
+    return localStorage.getItem('token');
+}
+
 function estaAutenticado() {
-    return localStorage.getItem('token') !== null;
+    return getToken() !== null;
 }
 
 /**
@@ -115,7 +119,7 @@ function verificarPermissaoAdmin() {
  * @returns {Promise} - Promise com o resultado da chamada
  */
 async function chamarAPI(endpoint, method = 'GET', body = null) {
-    const token = localStorage.getItem('token');
+    const token = getToken();
     
     if (!token) {
         console.error('Token não encontrado. Redirecionando para login...');


### PR DESCRIPTION
## Summary
- add a `getToken` function in `app.js`
- refactor authentication helpers to use the new token helper
- use `getToken` when calling API endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847755d80848323a27132dd3c1f7152