### PR TITLE
Implement basic time formatting

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -184,6 +184,22 @@ function formatarData(dataISO) {
  * @returns {string} - Horário formatado
  */
 function formatarHorario(horario) {
+    if (!horario) return '';
+
+    // Se já estiver no formato correto HH:MM, apenas normaliza zeros à esquerda
+    const partes = horario.split(':');
+    if (partes.length === 2) {
+        const horas = parseInt(partes[0], 10);
+        const minutos = parseInt(partes[1], 10);
+
+        if (!isNaN(horas) && !isNaN(minutos)) {
+            const h = String(horas).padStart(2, '0');
+            const m = String(minutos).padStart(2, '0');
+            return `${h}:${m}`;
+        }
+    }
+
+    // Caso não seja possível formatar, retorna original
     return horario;
 }
 


### PR DESCRIPTION
## Summary
- normalize time strings in `formatarHorario`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847768beae08323a5a13a7c4a5a77e1