### PR TITLE
Fix labs menu icon spacing

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -292,7 +292,7 @@ function adicionarLinkLabTurmas(containerSelector, isNavbar = false) {
         const link = document.createElement('a');
         link.className = 'nav-link admin-only';
         link.href = '/laboratorios-turmas.html';
-        link.innerHTML = '<i class="bi bi-building me-2"></i> Laboratórios e Turmas';
+        link.innerHTML = '<i class="bi bi-building"></i> Laboratórios e Turmas';
         
         // Insere antes do último item (Meu Perfil)
         const lastItem = container.querySelector('a[href="/perfil.html"]');


### PR DESCRIPTION
## Summary
- remove margin class from sidebar Labs link to match other icons

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68477fd04cb88323b8cf25f6021d8b57