### PR TITLE
Fix calendar day scrollbars

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -134,7 +134,8 @@ body {
   border: 1px solid #dee2e6;
   border-radius: 4px;
   padding: 5px;
-  overflow-y: auto; /* Permite rolagem vertical dentro das células */
+  /* Remove rolagem do contêiner principal para evitar barras desnecessárias */
+  overflow-y: hidden;
   aspect-ratio: 1 / 1; /* Mantém as células quadradas ao redimensionar */
   height: auto;
   min-height: 80px; /* Altura mínima para telas pequenas */


### PR DESCRIPTION
## Summary
- stop showing scrollbars on empty calendar cells by hiding overflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68478146feec83239f5f180d85ff522d