### PR TITLE
Remover footer escuro do sistema de agenda

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -582,3 +582,9 @@ footer {
   background-color: #28a745;
 }
 
+
+/* Oculta o footer escuro inferior para alinhar com o Sistema de Controle */
+footer.bg-dark {
+    display: none;
+}
+


### PR DESCRIPTION
## Summary
- ocultar o footer escuro para manter a interface igual ao Sistema de Controle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68487ca7f80083239ce4dd3b8bd84c70