### PR TITLE
Improve error message consistency

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from src.routes.turma import turma_bp
 from src.routes.sala import sala_bp
 from src.routes.instrutor import instrutor_bp
 from src.routes.ocupacao import ocupacao_bp
+from src.utils.errors import register_error_handlers
 
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(agendamento_bp, url_prefix='/api')
@@ -38,6 +39,8 @@ app.register_blueprint(turma_bp, url_prefix='/api')
 app.register_blueprint(sala_bp, url_prefix='/api')
 app.register_blueprint(instrutor_bp, url_prefix='/api')
 app.register_blueprint(ocupacao_bp, url_prefix='/api')
+
+register_error_handlers(app)
 
 # Rota principal para servir a página inicial
 @app.route('/')

--- a/src/routes/agendamento.py
+++ b/src/routes/agendamento.py
@@ -5,6 +5,12 @@ from src.models import db
 from src.models.agendamento import Agendamento
 from src.models.user import User
 from src.routes.user import verificar_autenticacao, verificar_admin
+from src.utils.messages import (
+    ERRO_NAO_AUTENTICADO,
+    ERRO_PERMISSAO_NEGADA,
+    ERRO_DADOS_INCOMPLETOS,
+    error_response,
+)
 
 agendamento_bp = Blueprint('agendamento', __name__)
 
@@ -17,7 +23,7 @@ def listar_agendamentos():
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     if verificar_admin(user):
         # Administradores veem todos os agendamentos
@@ -37,7 +43,7 @@ def obter_agendamento(id):
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     agendamento = Agendamento.query.get(id)
     if not agendamento:
@@ -45,7 +51,7 @@ def obter_agendamento(id):
     
     # Verifica permissões
     if not verificar_admin(user) and agendamento.usuario_id != user.id:
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     return jsonify(agendamento.to_dict())
 
@@ -58,14 +64,14 @@ def criar_agendamento():
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     data = request.json
     
     # Validação de dados
     campos_obrigatorios = ['data', 'laboratorio', 'turma', 'turno', 'horarios']
     if not all(campo in data for campo in campos_obrigatorios):
-        return jsonify({'erro': 'Dados incompletos'}), 400
+        return error_response(ERRO_DADOS_INCOMPLETOS, 400)
     
     # Verifica o formato da data
     try:
@@ -85,7 +91,7 @@ def criar_agendamento():
     
     # Usuários comuns só podem criar agendamentos para si mesmos
     if not verificar_admin(user) and usuario_id != user.id:
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     # Verifica se o usuário existe
     if usuario_id != user.id:
@@ -130,7 +136,7 @@ def atualizar_agendamento(id):
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     agendamento = Agendamento.query.get(id)
     if not agendamento:
@@ -138,7 +144,7 @@ def atualizar_agendamento(id):
     
     # Verifica permissões
     if not verificar_admin(user) and agendamento.usuario_id != user.id:
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     data = request.json
     
@@ -206,7 +212,7 @@ def remover_agendamento(id):
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     agendamento = Agendamento.query.get(id)
     if not agendamento:
@@ -214,7 +220,7 @@ def remover_agendamento(id):
     
     # Verifica permissões
     if not verificar_admin(user) and agendamento.usuario_id != user.id:
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     try:
         db.session.delete(agendamento)
@@ -232,7 +238,7 @@ def agendamentos_calendario(mes, ano):
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     # Valida o mês e ano
     if not (1 <= mes <= 12):
@@ -273,7 +279,7 @@ def agendamentos_calendario_periodo():
     de laboratório e turno."""
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
 
     data_inicio_str = request.args.get('data_inicio')
     data_fim_str = request.args.get('data_fim')
@@ -331,7 +337,7 @@ def verificar_disponibilidade():
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     # Obtém os parâmetros da requisição
     data_str = request.args.get('data')
@@ -340,7 +346,7 @@ def verificar_disponibilidade():
     
     # Validação de parâmetros
     if not all([data_str, laboratorio, turno]):
-        return jsonify({'erro': 'Parâmetros incompletos. Forneça data, laboratorio e turno.'}), 400
+        return error_response(ERRO_DADOS_INCOMPLETOS, 400)
     
     # Converte a data para o formato correto
     try:

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -2,6 +2,12 @@ from flask import Blueprint, request, jsonify
 from werkzeug.security import generate_password_hash
 from src.models import db
 from src.models.user import User
+from src.utils.messages import (
+    ERRO_NAO_AUTENTICADO,
+    ERRO_PERMISSAO_NEGADA,
+    ERRO_DADOS_INCOMPLETOS,
+    error_response,
+)
 
 user_bp = Blueprint('user', __name__)
 
@@ -52,10 +58,10 @@ def listar_usuarios():
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     if not verificar_admin(user):
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     usuarios = User.query.all()
     return jsonify([u.to_dict() for u in usuarios])
@@ -69,11 +75,11 @@ def obter_usuario(id):
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     # Verifica permissões
     if not verificar_admin(user) and user.id != id:
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     usuario = User.query.get(id)
     if not usuario:
@@ -92,7 +98,7 @@ def criar_usuario():
     
     # Validação de dados
     if not all(key in data for key in ['nome', 'email', 'username', 'senha']):
-        return jsonify({'erro': 'Dados incompletos'}), 400
+        return error_response(ERRO_DADOS_INCOMPLETOS, 400)
     
     # Verifica se o tipo é válido
     tipo = data.get('tipo', 'comum')
@@ -140,11 +146,11 @@ def atualizar_usuario(id):
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     # Verifica permissões
     if not verificar_admin(user) and user.id != id:
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     usuario = User.query.get(id)
     if not usuario:
@@ -189,11 +195,11 @@ def remover_usuario(id):
     """
     autenticado, user = verificar_autenticacao(request)
     if not autenticado:
-        return jsonify({'erro': 'Não autenticado'}), 401
+        return error_response(ERRO_NAO_AUTENTICADO, 401)
     
     # Verifica permissões
     if not verificar_admin(user):
-        return jsonify({'erro': 'Permissão negada'}), 403
+        return error_response(ERRO_PERMISSAO_NEGADA, 403)
     
     # Impede que um usuário remova a si mesmo
     if user.id == id:
@@ -219,7 +225,7 @@ def login():
     data = request.json
     
     if not all(key in data for key in ['username', 'senha']):
-        return jsonify({'erro': 'Dados incompletos'}), 400
+        return error_response(ERRO_DADOS_INCOMPLETOS, 400)
     
     usuario = User.query.filter_by(username=data['username']).first()
     

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -1,0 +1,22 @@
+from flask import jsonify
+from .messages import (
+    ERRO_REQUISICAO_MALFORMADA,
+    ERRO_NAO_ENCONTRADO,
+    FALLBACK_ERRO_GENERICO,
+)
+
+
+def register_error_handlers(app):
+    @app.errorhandler(400)
+    def handle_400(error):
+        desc = getattr(error, 'description', ERRO_REQUISICAO_MALFORMADA)
+        return jsonify({'erro': desc or ERRO_REQUISICAO_MALFORMADA}), 400
+
+    @app.errorhandler(404)
+    def handle_404(error):
+        desc = getattr(error, 'description', ERRO_NAO_ENCONTRADO)
+        return jsonify({'erro': desc or ERRO_NAO_ENCONTRADO}), 404
+
+    @app.errorhandler(500)
+    def handle_500(error):
+        return jsonify({'erro': FALLBACK_ERRO_GENERICO}), 500

--- a/src/utils/messages.py
+++ b/src/utils/messages.py
@@ -1,0 +1,14 @@
+from flask import jsonify
+
+ERRO_NAO_AUTENTICADO = 'Não autenticado'
+ERRO_PERMISSAO_NEGADA = 'Permissão negada'
+ERRO_REQUISICAO_MALFORMADA = 'Requisição malformada'
+ERRO_NAO_ENCONTRADO = 'Página ou item não encontrado'
+ERRO_INTERNO = 'Erro interno'
+FALLBACK_ERRO_GENERICO = 'Algo deu errado. Tente novamente mais tarde.'
+ERRO_DADOS_INCOMPLETOS = 'Dados incompletos'
+
+
+def error_response(message: str, status_code: int):
+    """Gera uma resposta de erro padronizada."""
+    return jsonify({'erro': message}), status_code


### PR DESCRIPTION
## Summary
- centralize error texts and helper in `src/utils`
- add global error handlers
- integrate new messages in user and agendamento routes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a0834f5c83239240b9164c8c4b3c