### PR TITLE
Add route coverage tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from datetime import date
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.models import db
+from src.models.user import User
+from src.models.sala import Sala
+from src.routes.user import user_bp
+from src.routes.sala import sala_bp
+from src.routes.agendamento import agendamento_bp
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test'
+    db.init_app(app)
+    app.register_blueprint(user_bp, url_prefix='/api')
+    app.register_blueprint(sala_bp, url_prefix='/api')
+    app.register_blueprint(agendamento_bp, url_prefix='/api')
+
+    with app.app_context():
+        db.create_all()
+        admin = User(
+            nome='Admin',
+            email='admin@example.com',
+            username='admin',
+            senha='password',
+            tipo='admin'
+        )
+        db.session.add(admin)
+        sala = Sala(nome='Sala Teste', capacidade=10)
+        db.session.add(sala)
+        db.session.commit()
+    return app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_agendamento_routes.py
+++ b/tests/test_agendamento_routes.py
@@ -1,0 +1,31 @@
+from datetime import date
+
+
+def login_admin(client):
+    resp = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def test_criar_e_listar_agendamento(client):
+    token = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post('/api/agendamentos', json={
+        'data': date.today().isoformat(),
+        'laboratorio': 'Lab1',
+        'turma': '1A',
+        'turno': 'Manhã',
+        'horarios': ['08:00', '09:00']
+    }, headers=headers)
+    assert resp.status_code == 201
+    ag_id = resp.get_json()['id']
+
+    resp = client.get(f'/api/agendamentos/{ag_id}', headers=headers)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['laboratorio'] == 'Lab1'
+
+    resp = client.get('/api/agendamentos', headers=headers)
+    assert resp.status_code == 200
+    ags = resp.get_json()
+    assert any(a['id'] == ag_id for a in ags)

--- a/tests/test_sala_routes.py
+++ b/tests/test_sala_routes.py
@@ -1,0 +1,23 @@
+
+def login_admin(client):
+    resp = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def test_criar_e_listar_sala(client):
+    token = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post('/api/salas', json={'nome': 'Sala Nova', 'capacidade': 20}, headers=headers)
+    assert resp.status_code == 201
+    sala_id = resp.get_json()['id']
+
+    resp = client.get(f'/api/salas/{sala_id}', headers=headers)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['nome'] == 'Sala Nova'
+
+    resp = client.get('/api/salas', headers=headers)
+    assert resp.status_code == 200
+    salas = resp.get_json()
+    assert any(s['id'] == sala_id for s in salas)

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -1,0 +1,33 @@
+
+def login_admin(client):
+    response = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
+    assert response.status_code == 200
+    return response.get_json()['token']
+
+
+def test_criar_usuario(client):
+    response = client.post('/api/usuarios', json={
+        'nome': 'Novo Usuario',
+        'email': 'novo@example.com',
+        'username': 'novo',
+        'senha': 'senha'
+    })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['username'] == 'novo'
+
+
+def test_login(client):
+    response = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert 'token' in json_data
+
+
+def test_listar_usuarios(client):
+    token = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    response = client.get('/api/usuarios', headers=headers)
+    assert response.status_code == 200
+    usuarios = response.get_json()
+    assert any(u['username'] == 'admin' for u in usuarios)


### PR DESCRIPTION
## Summary
- add fixture for reusable Flask test app
- test user creation, login and listing
- test room creation and listing
- test scheduling routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a9e29f548323813a848e0f0ed536