### PR TITLE
Fix DATABASE_URL handling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,9 @@ from src.models import db
 app = Flask(__name__, static_url_path='', static_folder='static')
 
 # Configuração do banco de dados
-db_uri = os.getenv('postgresql://postgres:BRtaZKVMSNjBDMiBMqPIzOcBSzDEsUjb@postgres.railway.internal:5432/railway')
+db_uri = os.getenv("DATABASE_URL", "").strip()
+if not db_uri:
+    db_uri = 'sqlite:///agenda_laboratorio.db'
 
 if db_uri.startswith('postgres://'):
     db_uri = db_uri.replace('postgres://', 'postgresql://', 1)


### PR DESCRIPTION
## Summary
- ensure `DATABASE_URL` environment variable is read properly
- default to a local SQLite database when the variable is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4e6d22a08323ace886010f21b4c3