### PR TITLE
Add setup and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@ Agenda de laboratórios e salas do SENAI
 
 ## Changelog
 Consulte o arquivo [CHANGELOG.md](CHANGELOG.md) para detalhes das versões.
+
+## Configuração rápida
+
+1. Instale as dependências do projeto:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Defina as variáveis de ambiente antes de rodar a aplicação ou os testes:
+
+   ```bash
+   export DATABASE_URL="postgresql://usuario:senha@host:5432/banco"
+   export SECRET_KEY="sua-chave-secreta"
+   ```
+
+   Se `DATABASE_URL` não for informado ou estiver vazio, o sistema utiliza por padrão um banco SQLite local (`agenda_laboratorio.db`).
+
+3. Execute a suíte de testes para verificar se tudo está funcionando:
+
+   ```bash
+   pytest
+   ```


### PR DESCRIPTION
## Summary
- document dependency installation
- show how to set `DATABASE_URL` and `SECRET_KEY`
- explain SQLite fallback
- add command to run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b545647e88323872dac372bd42465