### PR TITLE
Read SECRET_KEY from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Consulte o arquivo [CHANGELOG.md](CHANGELOG.md) para detalhes das versões.
    export SECRET_KEY="sua-chave-secreta"
    ```
 
+   A aplicação também reconhece a variável `FLASK_SECRET_KEY`. Caso nenhuma das duas esteja definida, é usado o valor padrão `chave-secreta-do-sistema-de-agenda`.
+
    Se `DATABASE_URL` não for informado ou estiver vazio, o sistema utiliza por padrão um banco SQLite local (`agenda_laboratorio.db`).
 
 3. Execute a suíte de testes para verificar se tudo está funcionando:

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ from src.routes.user import user_bp
 app = Flask(__name__, static_url_path='', static_folder='static')
 
 # Configuração do banco de dados
-db_uri = os.getenv( export DATABASE_URL="postgresql://postgres:BRtaZKVMSNjBDMiBMqPIzOcBSzDEsUjb@postgres.railway.internal:5432/railway").strip()
+db_uri = os.getenv("DATABASE_URL", "").strip()
 if not db_uri:
     db_uri = 'sqlite:///agenda_laboratorio.db'
 
@@ -24,7 +24,9 @@ if db_uri.startswith('postgres://'):
 
 app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['SECRET_KEY'] = 'chave-secreta-do-sistema-de-agenda'
+
+secret_key = os.getenv('SECRET_KEY') or os.getenv('FLASK_SECRET_KEY') or 'chave-secreta-do-sistema-de-agenda'
+app.config['SECRET_KEY'] = secret_key
 
 # Inicialização do banco de dados
 db.init_app(app)


### PR DESCRIPTION
## Summary
- allow configuring secret key from SECRET_KEY or FLASK_SECRET_KEY
- note this behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b56380f908323aba218fc906c61bf