### PR TITLE
Fix sala creation mode after editing

### DIFF
--- a/src/static/gerenciar-salas.html
+++ b/src/static/gerenciar-salas.html
@@ -117,7 +117,7 @@
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <h1 class="h2">Gerenciar Salas</h1>
                     <div class="btn-toolbar mb-2 mb-md-0">
-                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalSala">
+                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalSala" onclick="novaSala()">
                             <i class="bi bi-plus-circle me-1"></i>
                             Nova Sala
                         </button>
@@ -342,6 +342,10 @@
             carregarTiposSala();
             carregarRecursosSala();
             carregarSalas();
+
+            // Reseta o formulário sempre que o modal for fechado
+            const modalElem = document.getElementById('modalSala');
+            modalElem.addEventListener('hidden.bs.modal', novaSala);
         });
     </script>
 </body>

--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -322,11 +322,15 @@ async function salvarSala() {
         
         if (response.ok) {
             exibirAlerta(`Sala ${isEdicao ? 'atualizada' : 'criada'} com sucesso!`, 'success');
-            
+
             // Fecha o modal
             const modal = bootstrap.Modal.getInstance(document.getElementById('modalSala'));
             modal.hide();
-            
+
+            // Reseta o formulário e o estado de edição para evitar
+            // que uma nova criação seja tratada como atualização
+            novaSala();
+
             // Recarrega a lista
             carregarSalas();
         } else {


### PR DESCRIPTION
## Summary
- reset sala form on new modal open
- ensure modal reset when hidden and after save

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c325cd0fc83238eed73e952fecb69