### PR TITLE
Fix instructor form state after update

### DIFF
--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -117,7 +117,7 @@
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <h1 class="h2">Gerenciar Instrutores</h1>
                     <div class="btn-toolbar mb-2 mb-md-0">
-                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalInstrutor">
+                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalInstrutor" onclick="novoInstrutor()">
                             <i class="bi bi-plus-circle me-1"></i>
                             Novo Instrutor
                         </button>
@@ -380,6 +380,10 @@
             document.getElementById('instrutorAreaAtuacao').addEventListener('change', function() {
                 carregarCapacidadesSugeridas(this.value);
             });
+
+            // Reseta o formulário sempre que o modal for fechado
+            const modalElem = document.getElementById('modalInstrutor');
+            modalElem.addEventListener('hidden.bs.modal', novoInstrutor);
         });
     </script>
 </body>

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -408,11 +408,15 @@ async function salvarInstrutor() {
         
         if (response.ok) {
             exibirAlerta(`Instrutor ${isEdicao ? 'atualizado' : 'criado'} com sucesso!`, 'success');
-            
+
             // Fecha o modal
             const modal = bootstrap.Modal.getInstance(document.getElementById('modalInstrutor'));
             modal.hide();
-            
+
+            // Reseta o formulário e o estado de edição para evitar
+            // que uma nova criação seja tratada como atualização
+            novoInstrutor();
+
             // Recarrega a lista
             carregarInstrutores();
         } else {


### PR DESCRIPTION
## Summary
- clear instructor form when clicking "Novo Instrutor"
- reset form state when modal is closed and after saving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c35ac7ca4832385fe26520f1604eb