### PR TITLE
Atualiza layout do calendário de ocupações

### DIFF
--- a/src/static/calendario-salas.html
+++ b/src/static/calendario-salas.html
@@ -69,121 +69,126 @@
 
     <div class="container-fluid">
         <div class="row">
-            <!-- Sidebar -->
-            <nav class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
-                <div class="position-sticky pt-3">
-                    <ul class="nav flex-column">
-                        <li class="nav-item">
-                            <a class="nav-link" href="/dashboard-salas.html">
-                                <i class="bi bi-speedometer2 me-2"></i>
-                                Dashboard
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link active" href="/calendario-salas.html">
-                                <i class="bi bi-calendar3 me-2"></i>
-                                Calendário
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/gerenciar-salas.html">
-                                <i class="bi bi-building me-2"></i>
-                                Gerenciar Salas
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/gerenciar-instrutores.html">
-                                <i class="bi bi-person-badge me-2"></i>
-                                Gerenciar Instrutores
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/novo-agendamento-sala.html">
-                                <i class="bi bi-plus-circle me-2"></i>
-                                Nova Ocupação
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/perfil-salas.html">
-                                <i class="bi bi-person me-2"></i>
-                                Meu Perfil
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </nav>
-
-            <!-- Conteúdo Principal -->
-            <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
-                <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                    <h1 class="h2">Calendário de Ocupações</h1>
-                    <div class="btn-toolbar mb-2 mb-md-0">
-                        <button type="button" class="btn btn-primary me-2" onclick="window.location.href='/novo-agendamento-sala.html'">
-                            <i class="bi bi-plus-circle me-1"></i>
-                            Nova Ocupação
-                        </button>
-                        <div class="btn-group" role="group">
-                            <button type="button" class="btn btn-outline-secondary" onclick="calendar.changeView('dayGridMonth')">
-                                <i class="bi bi-calendar-month me-1"></i>Mês
-                            </button>
-                            <button type="button" class="btn btn-outline-secondary" onclick="calendar.changeView('timeGridWeek')">
-                                <i class="bi bi-calendar-week me-1"></i>Semana
-                            </button>
-                            <button type="button" class="btn btn-outline-secondary" onclick="calendar.changeView('timeGridDay')">
-                                <i class="bi bi-calendar-day me-1"></i>Dia
-                            </button>
-                        </div>
+            <!-- Sidebar em telas maiores -->
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <h5 class="mb-3">Menu Principal</h5>
+                    <div class="nav flex-column">
+                        <a class="nav-link" href="/dashboard-salas.html">
+                            <i class="bi bi-speedometer2"></i> Dashboard
+                        </a>
+                        <a class="nav-link active" href="/calendario-salas.html">
+                            <i class="bi bi-calendar3"></i> Calendário
+                        </a>
+                        <a class="nav-link" href="/gerenciar-salas.html">
+                            <i class="bi bi-building"></i> Gerenciar Salas
+                        </a>
+                        <a class="nav-link" href="/gerenciar-instrutores.html">
+                            <i class="bi bi-person-badge"></i> Gerenciar Instrutores
+                        </a>
+                        <a class="nav-link" href="/novo-agendamento-sala.html">
+                            <i class="bi bi-plus-circle"></i> Nova Ocupação
+                        </a>
+                        <a class="nav-link" href="/perfil-salas.html">
+                            <i class="bi bi-person"></i> Meu Perfil
+                        </a>
                     </div>
-                </div>
 
-                <!-- Filtros e Legenda -->
-                <div class="filtros-calendario">
-                    <div class="row align-items-center">
-                        <div class="col-md-8">
-                            <div class="row">
+                    <hr>
+
+                    <h5 class="mb-3">Filtros</h5>
+                    <form id="filtrosForm">
+                        <div class="mb-3">
+                            <label for="filtroSala" class="form-label">Sala</label>
+                            <select class="form-select" id="filtroSala">
+                                <option value="">Todas as salas</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="filtroInstrutor" class="form-label">Instrutor</label>
+                            <select class="form-select" id="filtroInstrutor">
+                                <option value="">Todos os instrutores</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="filtroTipoOcupacao" class="form-label">Tipo</label>
+                            <select class="form-select" id="filtroTipoOcupacao">
+                                <option value="">Todos os tipos</option>
+                            </select>
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">
+                            <i class="bi bi-funnel me-2"></i>Filtrar
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <!-- Conteúdo principal -->
+            <div class="col-lg-9">
+                <h2 class="mb-4">Calendário de Ocupações</h2>
+
+                <div id="alertContainer"></div>
+
+                <!-- Filtros em telas menores -->
+                <div class="d-lg-none mb-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">Filtros</h5>
+                        </div>
+                        <div class="card-body">
+                            <form id="filtrosMobileForm" class="row g-3">
                                 <div class="col-md-4">
-                                    <label for="filtroSala" class="form-label">Sala</label>
-                                    <select class="form-select form-select-sm" id="filtroSala" onchange="aplicarFiltrosCalendario()">
+                                    <label for="filtroSalaMobile" class="form-label">Sala</label>
+                                    <select class="form-select" id="filtroSalaMobile">
                                         <option value="">Todas as salas</option>
                                     </select>
                                 </div>
                                 <div class="col-md-4">
-                                    <label for="filtroInstrutor" class="form-label">Instrutor</label>
-                                    <select class="form-select form-select-sm" id="filtroInstrutor" onchange="aplicarFiltrosCalendario()">
+                                    <label for="filtroInstrutorMobile" class="form-label">Instrutor</label>
+                                    <select class="form-select" id="filtroInstrutorMobile">
                                         <option value="">Todos os instrutores</option>
                                     </select>
                                 </div>
                                 <div class="col-md-4">
-                                    <label for="filtroTipoOcupacao" class="form-label">Tipo</label>
-                                    <select class="form-select form-select-sm" id="filtroTipoOcupacao" onchange="aplicarFiltrosCalendario()">
+                                    <label for="filtroTipoOcupacaoMobile" class="form-label">Tipo</label>
+                                    <select class="form-select" id="filtroTipoOcupacaoMobile">
                                         <option value="">Todos os tipos</option>
                                     </select>
                                 </div>
-                            </div>
+                                <div class="col-12">
+                                    <button type="submit" class="btn btn-primary w-100">
+                                        <i class="bi bi-funnel me-2"></i>Filtrar
+                                    </button>
+                                </div>
+                            </form>
                         </div>
-                        <div class="col-md-4">
-                            <label class="form-label">Legenda</label>
-                            <div class="legenda-cores">
-                                <div class="legenda-item">
-                                    <div class="legenda-cor" style="background-color: #4CAF50;"></div>
-                                    <span>Aula Regular</span>
-                                </div>
-                                <div class="legenda-item">
-                                    <div class="legenda-cor" style="background-color: #FF9800;"></div>
-                                    <span>Evento</span>
-                                </div>
-                                <div class="legenda-item">
-                                    <div class="legenda-cor" style="background-color: #2196F3;"></div>
-                                    <span>Reunião</span>
-                                </div>
-                                <div class="legenda-item">
-                                    <div class="legenda-cor" style="background-color: #F44336;"></div>
-                                    <span>Manutenção</span>
-                                </div>
-                                <div class="legenda-item">
-                                    <div class="legenda-cor" style="background-color: #9C27B0;"></div>
-                                    <span>Reserva</span>
-                                </div>
+                    </div>
+                </div>
+
+                <!-- Legenda de Ocupações -->
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h6 class="card-subtitle mb-2 text-muted">Legenda de Ocupações</h6>
+                        <div class="legenda-cores">
+                            <div class="legenda-item">
+                                <div class="legenda-cor" style="background-color: #4CAF50;"></div>
+                                <span>Aula Regular</span>
+                            </div>
+                            <div class="legenda-item">
+                                <div class="legenda-cor" style="background-color: #FF9800;"></div>
+                                <span>Evento</span>
+                            </div>
+                            <div class="legenda-item">
+                                <div class="legenda-cor" style="background-color: #2196F3;"></div>
+                                <span>Reunião</span>
+                            </div>
+                            <div class="legenda-item">
+                                <div class="legenda-cor" style="background-color: #F44336;"></div>
+                                <span>Manutenção</span>
+                            </div>
+                            <div class="legenda-item">
+                                <div class="legenda-cor" style="background-color: #9C27B0;"></div>
+                                <span>Reserva</span>
                             </div>
                         </div>
                     </div>
@@ -198,11 +203,17 @@
                             </div>
                             <p class="mt-2">Carregando ocupações...</p>
                         </div>
-                        
+
                         <div id="calendario" style="display: none;"></div>
                     </div>
                 </div>
-            </main>
+
+                <div class="d-flex justify-content-end mt-4">
+                    <a href="/novo-agendamento-sala.html" class="btn btn-primary">
+                        <i class="bi bi-plus-circle me-2"></i>Nova Ocupação
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -276,7 +287,9 @@
             carregarSalasParaFiltro();
             carregarInstrutoresParaFiltro();
             carregarTiposOcupacao();
-            
+
+            configurarFiltros();
+
             // Verifica se há filtros na URL
             aplicarFiltrosURL();
         });

--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -86,9 +86,7 @@ async function carregarOcupacoes(dataInicio, dataFim) {
                 title: evento.title,
                 start: evento.start,
                 end: evento.end,
-                backgroundColor: evento.backgroundColor,
-                borderColor: evento.borderColor,
-                className: `ocupacao-${evento.extendedProps.tipo_ocupacao}`,
+                className: getClasseTurno(evento.extendedProps.turno),
                 extendedProps: evento.extendedProps
             }));
         } else {
@@ -176,6 +174,32 @@ async function carregarTiposOcupacao() {
 function aplicarFiltrosCalendario() {
     if (calendar) {
         calendar.refetchEvents();
+    }
+}
+
+// Configura formulários de filtros (desktop e mobile)
+function configurarFiltros() {
+    const form = document.getElementById('filtrosForm');
+    const formMobile = document.getElementById('filtrosMobileForm');
+
+    if (form) {
+        form.addEventListener('submit', e => {
+            e.preventDefault();
+            document.getElementById('filtroSalaMobile').value = document.getElementById('filtroSala').value;
+            document.getElementById('filtroInstrutorMobile').value = document.getElementById('filtroInstrutor').value;
+            document.getElementById('filtroTipoOcupacaoMobile').value = document.getElementById('filtroTipoOcupacao').value;
+            aplicarFiltrosCalendario();
+        });
+    }
+
+    if (formMobile) {
+        formMobile.addEventListener('submit', e => {
+            e.preventDefault();
+            document.getElementById('filtroSala').value = document.getElementById('filtroSalaMobile').value;
+            document.getElementById('filtroInstrutor').value = document.getElementById('filtroInstrutorMobile').value;
+            document.getElementById('filtroTipoOcupacao').value = document.getElementById('filtroTipoOcupacaoMobile').value;
+            aplicarFiltrosCalendario();
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- reorganiza a página do calendário de ocupações com sidebar e filtros
- adiciona formulário de filtros para dispositivos móveis
- colore eventos conforme turno e sincroniza filtros desktop/mobile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684c5eb7c39083239120f072d9cb46a0