### PR TITLE
Add Gerenciar Turmas tab to occupancy UI

### DIFF
--- a/src/static/calendario-salas.html
+++ b/src/static/calendario-salas.html
@@ -45,6 +45,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
                         </a>
@@ -85,6 +90,9 @@
                         </a>
                         <a class="nav-link" href="/gerenciar-instrutores.html">
                             <i class="bi bi-person-badge"></i> Gerenciar Instrutores
+                        </a>
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building"></i> Gerenciar Turmas
                         </a>
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle"></i> Nova Ocupação

--- a/src/static/dashboard-salas.html
+++ b/src/static/dashboard-salas.html
@@ -44,6 +44,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
                         </a>
@@ -84,6 +89,9 @@
                         </a>
                         <a class="nav-link" href="/gerenciar-instrutores.html">
                             <i class="bi bi-person-badge"></i> Gerenciar Instrutores
+                        </a>
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building"></i> Gerenciar Turmas
                         </a>
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle"></i> Nova Ocupação
@@ -203,6 +211,14 @@
                                             <button type="button" class="btn btn-outline-warning quick-action" onclick="window.location.href='/gerenciar-instrutores.html'">
                                                 <i class="bi bi-person-badge d-block mb-2" style="font-size: 2rem;"></i>
                                                 Gerenciar Instrutores
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-3 mb-3" id="acaoGerenciarTurmas" style="display: none;">
+                                        <div class="d-grid">
+                                            <button type="button" class="btn btn-outline-secondary quick-action" onclick="window.location.href='/gerenciar-turmas.html'">
+                                                <i class="bi bi-building d-block mb-2" style="font-size: 2rem;"></i>
+                                                Gerenciar Turmas
                                             </button>
                                         </div>
                                     </div>
@@ -329,6 +345,7 @@
             if (isAdmin()) {
                 document.getElementById('acaoGerenciarSalas').style.display = 'block';
                 document.getElementById('acaoGerenciarInstrutores').style.display = 'block';
+                document.getElementById('acaoGerenciarTurmas').style.display = 'block';
             }
             
             // Carrega dados do dashboard

--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -44,6 +44,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
                         </a>
@@ -84,6 +89,9 @@
                         </a>
                         <a class="nav-link active" href="/gerenciar-instrutores.html">
                             <i class="bi bi-person-badge"></i> Gerenciar Instrutores
+                        </a>
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building"></i> Gerenciar Turmas
                         </a>
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle"></i> Nova Ocupação

--- a/src/static/gerenciar-salas.html
+++ b/src/static/gerenciar-salas.html
@@ -44,6 +44,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
                         </a>
@@ -84,6 +89,9 @@
                         </a>
                         <a class="nav-link" href="/gerenciar-instrutores.html">
                             <i class="bi bi-person-badge"></i> Gerenciar Instrutores
+                        </a>
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building"></i> Gerenciar Turmas
                         </a>
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle"></i> Nova Ocupação

--- a/src/static/gerenciar-turmas.html
+++ b/src/static/gerenciar-turmas.html
@@ -16,7 +16,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                Sistema de Agenda de Laboratório
+                Sistema de Controle de Ocupação
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -24,23 +24,33 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="/index.html">
+                        <a class="nav-link" href="/dashboard-salas.html">
                             <i class="bi bi-speedometer2 me-1"></i> Dashboard
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/calendario.html">
+                        <a class="nav-link" href="/calendario-salas.html">
                             <i class="bi bi-calendar3 me-1"></i> Calendário
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
+                        <a class="nav-link" href="/gerenciar-salas.html">
+                            <i class="bi bi-building me-1"></i> Gerenciar Salas
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/gerenciar-instrutores.html">
+                            <i class="bi bi-person-badge me-1"></i> Gerenciar Instrutores
                         </a>
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link active" href="/gerenciar-turmas.html">
                             <i class="bi bi-building me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/novo-agendamento-sala.html">
+                            <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
                         </a>
                     </li>
                 </ul>
@@ -52,7 +62,7 @@
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
                             <li>
-                                <a class="dropdown-item" href="/perfil.html">
+                                <a class="dropdown-item" href="/perfil-salas.html">
                                     <i class="bi bi-person me-2"></i> Meu Perfil
                                 </a>
                             </li>
@@ -77,19 +87,25 @@
                 <div class="sidebar rounded shadow-sm">
                     <h5 class="mb-3">Menu Principal</h5>
                     <div class="nav flex-column">
-                        <a class="nav-link" href="/index.html">
+                        <a class="nav-link" href="/dashboard-salas.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
-                        <a class="nav-link" href="/calendario.html">
+                        <a class="nav-link" href="/calendario-salas.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
-                        <a class="nav-link" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle"></i> Novo Agendamento
+                        <a class="nav-link" href="/gerenciar-salas.html">
+                            <i class="bi bi-building"></i> Gerenciar Salas
+                        </a>
+                        <a class="nav-link" href="/gerenciar-instrutores.html">
+                            <i class="bi bi-person-badge"></i> Gerenciar Instrutores
                         </a>
                         <a class="nav-link active admin-only" href="/gerenciar-turmas.html">
                             <i class="bi bi-building"></i> Gerenciar Turmas
                         </a>
-                        <a class="nav-link" href="/perfil.html">
+                        <a class="nav-link" href="/novo-agendamento-sala.html">
+                            <i class="bi bi-plus-circle"></i> Nova Ocupação
+                        </a>
+                        <a class="nav-link" href="/perfil-salas.html">
                             <i class="bi bi-person"></i> Meu Perfil
                         </a>
                     </div>
@@ -154,7 +170,7 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col-md-6">
-                    <p class="mb-0">&copy; 2025 Sistema de Agenda de Laboratório</p>
+                    <p class="mb-0">&copy; 2025 Sistema de Controle de Ocupação</p>
                 </div>
                 <div class="col-md-6 text-md-end">
                     <p class="mb-0">Versão 1.0</p>

--- a/src/static/novo-agendamento-sala.html
+++ b/src/static/novo-agendamento-sala.html
@@ -44,6 +44,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link active" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
                         </a>
@@ -84,6 +89,9 @@
                         </a>
                         <a class="nav-link" href="/gerenciar-instrutores.html">
                             <i class="bi bi-person-badge"></i> Gerenciar Instrutores
+                        </a>
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building"></i> Gerenciar Turmas
                         </a>
                         <a class="nav-link active" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle"></i> Nova Ocupação

--- a/src/static/perfil-salas.html
+++ b/src/static/perfil-salas.html
@@ -44,6 +44,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
                         </a>
@@ -93,6 +98,9 @@
                         </a>
                         <a class="nav-link" href="/gerenciar-instrutores.html">
                             <i class="bi bi-person-badge"></i> Gerenciar Instrutores
+                        </a>
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building"></i> Gerenciar Turmas
                         </a>
                         <a class="nav-link" href="/novo-agendamento-sala.html">
                             <i class="bi bi-plus-circle"></i> Nova Ocupação


### PR DESCRIPTION
## Summary
- add Gerenciar Turmas link to occupancy navbars and sidebars
- show quick action for turmas on dashboard
- expose action in dashboard JS
- adjust Gerenciar Turmas page to match occupancy branding and routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb56c8fcc83239e99813ec4684e02