### PR TITLE
Fix JavaScript not executing on Gerenciar Turmas

### DIFF
--- a/src/static/gerenciar-turmas.html
+++ b/src/static/gerenciar-turmas.html
@@ -200,6 +200,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script>
 document.addEventListener('DOMContentLoaded', function() {
     verificarAutenticacao();
     verificarPermissaoAdmin();


### PR DESCRIPTION
## Summary
- fix missing opening `<script>` tag in `gerenciar-turmas.html`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cbced46f88323a0f8022152f2aee5