### PR TITLE
Fix period display when editing reservations

### DIFF
--- a/src/static/js/nova-ocupacao.js
+++ b/src/static/js/nova-ocupacao.js
@@ -165,8 +165,8 @@ async function carregarOcupacaoParaEdicao(id) {
             // Preenche o formulário
             document.getElementById('cursoEvento').value = ocupacaoEditando.curso_evento;
             document.getElementById('tipoOcupacao').value = ocupacaoEditando.tipo_ocupacao;
-            document.getElementById('dataInicio').value = ocupacaoEditando.data;
-            document.getElementById('dataFim').value = ocupacaoEditando.data;
+            document.getElementById('dataInicio').value = ocupacaoEditando.data_inicio || ocupacaoEditando.data;
+            document.getElementById('dataFim').value = ocupacaoEditando.data_fim || ocupacaoEditando.data;
             document.getElementById('turno').value = obterTurnoPorHorario(ocupacaoEditando.horario_inicio, ocupacaoEditando.horario_fim);
             document.getElementById('salaOcupacao').value = ocupacaoEditando.sala_id;
             document.getElementById('instrutorOcupacao').value = ocupacaoEditando.instrutor_id || '';


### PR DESCRIPTION
## Summary
- return full reservation period in `GET /ocupacoes/<id>`
- show start and end dates when editing an occupation
- test retrieving full period for an occupation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccdacf24883238ebdf38d59b83a0d