### PR TITLE
Fix menus and editing in occupancy

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -399,7 +399,8 @@ document.addEventListener('DOMContentLoaded', function() {
             '/perfil-salas.html',
             '/usuarios.html',
             '/perfil.html',
-            '/perfil-usuarios.html'
+            '/perfil-usuarios.html',
+            '/gerenciar-turmas.html'
         ];
 
         if (!paginasOcupacao.includes(paginaAtual)) {

--- a/src/static/novo-agendamento-sala.html
+++ b/src/static/novo-agendamento-sala.html
@@ -211,7 +211,7 @@
     <script src="/js/app.js"></script>
     <script src="/js/nova-ocupacao.js"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', async function() {
             // Verifica autenticação
             if (!estaAutenticado()) {
                 window.location.href = '/admin-login.html';
@@ -223,10 +223,10 @@
             document.getElementById('nomeUsuarioNav').textContent = usuario.nome;
             
             // Carrega dados iniciais
-            carregarTiposOcupacao();
-            carregarSalas();
-            carregarInstrutores();
-            carregarTurmasSelect();
+            await carregarTiposOcupacao();
+            await carregarSalas();
+            await carregarInstrutores();
+            await carregarTurmasSelect();
             
             // Define data mínima como hoje
             const hoje = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
## Summary
- keep "Laboratorios e Turmas" link out of occupation pages
- wait for async loads before editing an occupation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd58cd8648323a965d384c3779b51