### PR TITLE
Allow past start dates for room occupancy

### DIFF
--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -211,8 +211,6 @@ def criar_ocupacao():
         if data_inicio > data_fim:
             return jsonify({'erro': 'Data de início deve ser anterior ou igual à data de fim'}), 400
 
-        if data_inicio < date.today():
-            return jsonify({'erro': 'Não é possível agendar para datas passadas'}), 400
 
         if data['turno'] not in TURNOS_PADRAO:
             return jsonify({'erro': 'Turno inválido'}), 400
@@ -345,13 +343,9 @@ def atualizar_ocupacao(id):
 
         if 'data_inicio' in data:
             data_ocupacao = datetime.strptime(data['data_inicio'], '%Y-%m-%d').date()
-            if data_ocupacao < date.today():
-                return jsonify({'erro': 'Não é possível agendar para datas passadas'}), 400
             ocupacao.data = data_ocupacao
         elif 'data' in data:
             data_ocupacao = datetime.strptime(data['data'], '%Y-%m-%d').date()
-            if data_ocupacao < date.today():
-                return jsonify({'erro': 'Não é possível agendar para datas passadas'}), 400
             ocupacao.data = data_ocupacao
 
         if 'turno' in data:

--- a/src/static/js/nova-ocupacao.js
+++ b/src/static/js/nova-ocupacao.js
@@ -188,19 +188,13 @@ async function carregarOcupacaoParaEdicao(id) {
 function validarDatas() {
     const inicio = document.getElementById('dataInicio').value;
     const fim = document.getElementById('dataFim').value;
-    const hoje = new Date().toISOString().split('T')[0];
-
-    if (inicio && inicio < hoje) {
-        document.getElementById('dataInicio').setCustomValidity('Data não pode ser no passado');
-    } else {
-        document.getElementById('dataInicio').setCustomValidity('');
-    }
-
     if (inicio && fim && fim < inicio) {
         document.getElementById('dataFim').setCustomValidity('Data de fim deve ser posterior ou igual à data de início');
     } else {
         document.getElementById('dataFim').setCustomValidity('');
     }
+
+    document.getElementById('dataInicio').setCustomValidity('');
 }
 
 // Verifica disponibilidade de forma dinâmica

--- a/src/static/novo-agendamento-sala.html
+++ b/src/static/novo-agendamento-sala.html
@@ -227,12 +227,7 @@
             await carregarSalas();
             await carregarInstrutores();
             await carregarTurmasSelect();
-            
-            // Define data mínima como hoje
-            const hoje = new Date().toISOString().split('T')[0];
-            document.getElementById('dataInicio').min = hoje;
-            document.getElementById('dataFim').min = hoje;
-            
+
             // Adiciona listeners para validação em tempo real
             adicionarListenersValidacao();
         });


### PR DESCRIPTION
## Summary
- allow creating and editing room occupancies with past start dates
- remove date-minimum restrictions from the Nova Ocupação page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507b8375ac8323b4cf1f6df133c969