### PR TITLE
Implement daily shift summary in calendar

### DIFF
--- a/src/static/calendario-salas.html
+++ b/src/static/calendario-salas.html
@@ -245,6 +245,20 @@
         </div>
     </div>
 
+    <!-- Modal Resumo do Dia -->
+    <div class="modal fade" id="modalResumoDia" tabindex="-1" aria-labelledby="modalResumoDiaLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="modalResumoDiaLabel">Resumo do Dia</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body" id="conteudoResumoDia">
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Modal de Confirmação de Exclusão -->
     <div class="modal fade" id="modalExcluirOcupacao" tabindex="-1" aria-labelledby="modalExcluirOcupacaoLabel" aria-hidden="true">
         <div class="modal-dialog">

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -303,6 +303,28 @@ small, .small {
   border-left: 3px solid #512DA8;
 }
 
+/* Resumo de ocupações por turno no calendário */
+.resumo-turno {
+  font-size: 0.7rem;
+  margin-top: 2px;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.resumo-manha {
+  background-color: var(--turno-manha-color);
+}
+
+.resumo-tarde {
+  background-color: var(--turno-tarde-color);
+  color: #fff;
+}
+
+.resumo-noite {
+  background-color: var(--turno-noite-color);
+  color: #fff;
+}
+
 /* Notificações */
 .notificacao-badge {
   position: absolute;


### PR DESCRIPTION
## Summary
- provide `/ocupacoes/resumo-periodo` endpoint to return per-day/shift room usage
- show shift summary on calendar cells with modal details
- add styles for new shift summary tags
- test new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509043ac78832380022adbc13ef21d