### PR TITLE
Improve day summary UI

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -349,6 +349,16 @@ small, .small {
   font-size: 0.8rem;
 }
 
+/* Permite clicar no cabeçalho do resumo para expandir/contrair */
+.resumo-card-header {
+  cursor: pointer;
+}
+
+/* Esconde o corpo quando o card está minimizado */
+.resumo-card-collapsed .card-body {
+  display: none;
+}
+
 @media (max-width: 576px) {
   .resumo-card-header span.badge {
     font-size: 0.7rem;

--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -183,7 +183,10 @@ function mostrarResumoDia(dataStr) {
 
         const header = document.createElement('div');
         header.className = `card-header resumo-card-header resumo-card-${slugifyTurno(turno)}`;
-        header.innerHTML = `<div class="d-flex justify-content-between align-items-center"><span>${turno}</span><span class="badge bg-secondary">${info.ocupadas}/${info.total_salas} Salas</span></div>`;
+        const icon = document.createElement('i');
+        icon.className = 'bi bi-chevron-up toggle-icon ms-2';
+        header.innerHTML = `<div class="d-flex justify-content-between align-items-center"><span>${turno}</span><span><span class="badge bg-secondary">${info.ocupadas}/${info.total_salas} Salas</span></span></div>`;
+        header.querySelector('span span').appendChild(icon);
         card.appendChild(header);
 
         const body = document.createElement('div');
@@ -208,6 +211,12 @@ function mostrarResumoDia(dataStr) {
 
         body.innerHTML = html;
         card.appendChild(body);
+        header.addEventListener('click', () => {
+            body.classList.toggle('d-none');
+            card.classList.toggle('resumo-card-collapsed');
+            icon.classList.toggle('bi-chevron-up');
+            icon.classList.toggle('bi-chevron-down');
+        });
         container.appendChild(card);
     });
 


### PR DESCRIPTION
## Summary
- allow collapse/expand for each shift in day summary
- tweak calendar styles for collapsible cards

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68515c6f1f608323a5a9876989318931