### PR TITLE
Fix deletion in daily summary

### DIFF
--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -511,9 +511,14 @@ function excluirOcupacaoResumo(id) {
 
 // Exclui ocupação
 function excluirOcupacao(id, nome, grupoId) {
-    // Fecha modal atual
-    const modal = bootstrap.Modal.getInstance(document.getElementById('modalDetalhesOcupacao'));
-    modal.hide();
+    // Fecha modais que possam estar abertos
+    const detalhesEl = document.getElementById('modalDetalhesOcupacao');
+    const detalhesModal = detalhesEl ? bootstrap.Modal.getInstance(detalhesEl) : null;
+    if (detalhesModal) detalhesModal.hide();
+
+    const resumoEl = document.getElementById('modalResumoDia');
+    const resumoModal = resumoEl ? bootstrap.Modal.getInstance(resumoEl) : null;
+    if (resumoModal) resumoModal.hide();
 
     // Configura modal de exclusão
     let resumo = `<strong>${nome}</strong>`;


### PR DESCRIPTION
## Summary
- hide open modals before showing the delete confirmation
- ensure delete confirmation works from daily summary view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685216a59a9c8323ab610d72f1c67daf