### PR TITLE
Fix hardcoded SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Consulte o arquivo [CHANGELOG.md](CHANGELOG.md) para detalhes das versões.
    export SECRET_KEY="sua-chave-secreta"
    ```
 
-   A aplicação também reconhece a variável `FLASK_SECRET_KEY`. Caso nenhuma das duas esteja definida, é usado o valor padrão `chave-secreta-do-sistema-de-agenda`.
+   A aplicação também reconhece a variável `FLASK_SECRET_KEY`. Uma das duas deve estar definida; se nenhuma estiver presente, a aplicação aborta a inicialização. Use um valor longo e aleatório (por exemplo, `export SECRET_KEY=$(openssl rand -hex 32)`).
 
    Se `DATABASE_URL` não for informado ou estiver vazio, o sistema utiliza por padrão um banco SQLite local (`agenda_laboratorio.db`).
 

--- a/src/main.py
+++ b/src/main.py
@@ -68,7 +68,11 @@ def create_app():
     app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-    secret_key = os.getenv('SECRET_KEY') or os.getenv('FLASK_SECRET_KEY') or 'chave-secreta-do-sistema-de-agenda'
+    secret_key = os.getenv('SECRET_KEY') or os.getenv('FLASK_SECRET_KEY')
+    if not secret_key:
+        raise RuntimeError(
+            "SECRET_KEY environment variable must be set for JWT signing"
+        )
     app.config['SECRET_KEY'] = secret_key
 
     db.init_app(app)


### PR DESCRIPTION
## Summary
- require SECRET_KEY environment variable
- update docs to explain secret key requirement

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfd2e65608323a6a865543ba57148