### PR TITLE
Fix XSS in frontend

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -4,6 +4,17 @@
 // Constantes globais
 const API_URL = '/api';
 
+/**
+ * Escapes HTML special characters to prevent XSS attacks.
+ * @param {string} str - Text to escape
+ * @returns {string} - Escaped HTML string
+ */
+function escapeHTML(str) {
+    const div = document.createElement('div');
+    div.textContent = String(str);
+    return div.innerHTML;
+}
+
 // Funções de autenticação
 /**
  * Realiza o login do usuário
@@ -264,16 +275,19 @@ function formatarHorario(horario) {
 function exibirAlerta(mensagem, tipo = 'info', containerId = 'alertContainer') {
     const container = document.getElementById(containerId);
     if (!container) return;
-    
+
     const alertDiv = document.createElement('div');
     alertDiv.className = `alert alert-${tipo} alert-dismissible fade show`;
     alertDiv.role = 'alert';
-    
-    alertDiv.innerHTML = `
-        ${mensagem}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-    `;
-    
+
+    alertDiv.textContent = mensagem;
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close';
+    closeBtn.setAttribute('data-bs-dismiss', 'alert');
+    closeBtn.setAttribute('aria-label', 'Fechar');
+    alertDiv.appendChild(closeBtn);
+
     container.appendChild(alertDiv);
     
     // Remove o alerta após 5 segundos

--- a/src/static/js/calendario-labs.js
+++ b/src/static/js/calendario-labs.js
@@ -91,18 +91,18 @@ function mostrarDetalhesAgendamento(agendamento) {
     let horariosFormatados = '';
     try {
         const horarios = JSON.parse(agendamento.horarios);
-        horariosFormatados = horarios.join('<br>');
+        horariosFormatados = horarios.map(h => escapeHTML(h)).join('<br>');
     } catch (e) {
-        horariosFormatados = agendamento.horarios;
+        horariosFormatados = escapeHTML(agendamento.horarios);
     }
 
     modalBody.innerHTML = `
-        <div class="mb-3"><strong>Laboratório:</strong> ${agendamento.laboratorio}</div>
-        <div class="mb-3"><strong>Turma:</strong> ${agendamento.turma}</div>
-        <div class="mb-3"><strong>Data:</strong> ${formatarData(agendamento.data)}</div>
-        <div class="mb-3"><strong>Turno:</strong> <span class="badge ${getClasseTurno(agendamento.turno)}">${agendamento.turno}</span></div>
+        <div class="mb-3"><strong>Laboratório:</strong> ${escapeHTML(agendamento.laboratorio)}</div>
+        <div class="mb-3"><strong>Turma:</strong> ${escapeHTML(agendamento.turma)}</div>
+        <div class="mb-3"><strong>Data:</strong> ${escapeHTML(formatarData(agendamento.data))}</div>
+        <div class="mb-3"><strong>Turno:</strong> <span class="badge ${getClasseTurno(agendamento.turno)}">${escapeHTML(agendamento.turno)}</span></div>
         <div class="mb-3"><strong>Horários:</strong><br>${horariosFormatados}</div>
-        <div class="mb-3"><strong>Agendado por:</strong> ${agendamento.usuario_nome || 'Não informado'}</div>
+        <div class="mb-3"><strong>Agendado por:</strong> ${escapeHTML(agendamento.usuario_nome || 'Não informado')}</div>
     `;
 
     const usuario = getUsuarioLogado();

--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -583,14 +583,17 @@ function exibirAlerta(mensagem, tipo) {
     // Remove alertas existentes
     const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
     alertasExistentes.forEach(alerta => alerta.remove());
-    
+
     // Cria novo alerta
     const alerta = document.createElement('div');
     alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
-    alerta.innerHTML = `
-        ${mensagem}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    `;
+    alerta.textContent = mensagem;
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close';
+    closeBtn.setAttribute('data-bs-dismiss', 'alert');
+    closeBtn.setAttribute('aria-label', 'Close');
+    alerta.appendChild(closeBtn);
     
     // Insere no início do main
     const main = document.querySelector('main');

--- a/src/static/js/dashboard-salas.js
+++ b/src/static/js/dashboard-salas.js
@@ -157,35 +157,35 @@ function renderizarProximasOcupacoes() {
     ocupacoesLimitadas.forEach(ocupacao => {
         const item = document.createElement('div');
         item.className = `ocupacao-item ${ocupacao.tipo_ocupacao}`;
-        
+
         const dataFormatada = formatarDataCurta(ocupacao.data);
         const isHoje = ocupacao.data === new Date().toISOString().split('T')[0];
-        
+
         item.innerHTML = `
             <div class="d-flex justify-content-between align-items-start">
                 <div>
-                    <h6 class="mb-1">${ocupacao.curso_evento}</h6>
+                    <h6 class="mb-1">${escapeHTML(ocupacao.curso_evento)}</h6>
                     <small class="text-muted">
-                        <i class="bi bi-building me-1"></i>${ocupacao.sala_nome || 'Sala não informada'}
+                        <i class="bi bi-building me-1"></i>${escapeHTML(ocupacao.sala_nome || 'Sala não informada')}
                     </small>
                     ${ocupacao.instrutor_nome ? `
                         <br><small class="text-muted">
-                            <i class="bi bi-person-badge me-1"></i>${ocupacao.instrutor_nome}
+                            <i class="bi bi-person-badge me-1"></i>${escapeHTML(ocupacao.instrutor_nome)}
                         </small>
                     ` : ''}
                 </div>
                 <div class="text-end">
                     <small class="fw-bold ${isHoje ? 'text-primary' : ''}">
-                        ${isHoje ? 'HOJE' : dataFormatada}
+                        ${isHoje ? 'HOJE' : escapeHTML(dataFormatada)}
                     </small>
                     <br>
                     <small class="text-muted">
-                        ${ocupacao.horario_inicio} - ${ocupacao.horario_fim}
+                        ${escapeHTML(ocupacao.horario_inicio)} - ${escapeHTML(ocupacao.horario_fim)}
                     </small>
                 </div>
             </div>
         `;
-        
+
         container.appendChild(item);
     });
     

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -480,14 +480,17 @@ function exibirAlerta(mensagem, tipo) {
     // Remove alertas existentes
     const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
     alertasExistentes.forEach(alerta => alerta.remove());
-    
+
     // Cria novo alerta
     const alerta = document.createElement('div');
     alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
-    alerta.innerHTML = `
-        ${mensagem}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    `;
+    alerta.textContent = mensagem;
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close';
+    closeBtn.setAttribute('data-bs-dismiss', 'alert');
+    closeBtn.setAttribute('aria-label', 'Close');
+    alerta.appendChild(closeBtn);
     
     // Insere no início do main
     const main = document.querySelector('main');

--- a/src/static/js/nova-ocupacao.js
+++ b/src/static/js/nova-ocupacao.js
@@ -349,14 +349,17 @@ function exibirAlerta(mensagem, tipo) {
     // Remove alertas existentes
     const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
     alertasExistentes.forEach(alerta => alerta.remove());
-    
+
     // Cria novo alerta
     const alerta = document.createElement('div');
     alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
-    alerta.innerHTML = `
-        ${mensagem}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    `;
+    alerta.textContent = mensagem;
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close';
+    closeBtn.setAttribute('data-bs-dismiss', 'alert');
+    closeBtn.setAttribute('aria-label', 'Close');
+    alerta.appendChild(closeBtn);
     
     // Insere no início do main
     const main = document.querySelector('main');

--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -347,14 +347,17 @@ function exibirAlerta(mensagem, tipo) {
     // Remove alertas existentes
     const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
     alertasExistentes.forEach(alerta => alerta.remove());
-    
+
     // Cria novo alerta
     const alerta = document.createElement('div');
     alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
-    alerta.innerHTML = `
-        ${mensagem}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    `;
+    alerta.textContent = mensagem;
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close';
+    closeBtn.setAttribute('data-bs-dismiss', 'alert');
+    closeBtn.setAttribute('aria-label', 'Close');
+    alerta.appendChild(closeBtn);
     
     // Insere no início do main
     const main = document.querySelector('main');


### PR DESCRIPTION
## Summary
- escape HTML before injecting user data
- use textContent when building alert messages to avoid unsafe HTML

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0be8bb248323b6630e0ae135f565