### PR TITLE
Ensure password change verifies current password

### DIFF
--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -224,6 +224,16 @@ def atualizar_usuario(id):
     
     # Atualiza a senha se fornecida
     if 'senha' in data:
+        senha_atual = data.get('senha_atual')
+
+        # Se quem está alterando não é um administrador editando outro usuário,
+        # exige a senha atual para confirmar a operação
+        if not verificar_admin(user) or user.id == id:
+            if not senha_atual:
+                return jsonify({'erro': 'Senha atual obrigatória'}), 400
+            if not usuario.check_senha(senha_atual):
+                return jsonify({'erro': 'Senha atual incorreta'}), 403
+
         usuario.set_senha(data['senha'])
     
     try:

--- a/src/static/perfil-salas.html
+++ b/src/static/perfil-salas.html
@@ -276,13 +276,11 @@
                 }
                 
                 try {
-                    // Aqui seria necessário verificar a senha atual no backend
-                    // Como não temos essa rota específica, vamos simular
-                    
                     const usuario = getUsuarioLogado();
-                    
+
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
-                        senha: novaSenha
+                        senha: novaSenha,
+                        senha_atual: senhaAtual
                     });
                     
                     exibirAlerta('Senha alterada com sucesso!', 'success');

--- a/src/static/perfil-usuarios.html
+++ b/src/static/perfil-usuarios.html
@@ -230,13 +230,11 @@
                 }
                 
                 try {
-                    // Aqui seria necessário verificar a senha atual no backend
-                    // Como não temos essa rota específica, vamos simular
-                    
                     const usuario = getUsuarioLogado();
-                    
+
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
-                        senha: novaSenha
+                        senha: novaSenha,
+                        senha_atual: senhaAtual
                     });
                     
                     exibirAlerta('Senha alterada com sucesso!', 'success');

--- a/src/static/perfil.html
+++ b/src/static/perfil.html
@@ -252,13 +252,11 @@
                 }
                 
                 try {
-                    // Aqui seria necessário verificar a senha atual no backend
-                    // Como não temos essa rota específica, vamos simular
-                    
                     const usuario = getUsuarioLogado();
-                    
+
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
-                        senha: novaSenha
+                        senha: novaSenha,
+                        senha_atual: senhaAtual
                     });
                     
                     exibirAlerta('Senha alterada com sucesso!', 'success');

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -42,3 +42,45 @@ def test_refresh_token(client):
     assert resp.status_code == 200
     dados = resp.get_json()
     assert 'token' in dados
+
+
+def test_atualizar_senha_requer_verificacao(client):
+    # cria usuario normal
+    resp = client.post('/api/usuarios', json={
+        'nome': 'Teste',
+        'email': 'teste@example.com',
+        'username': 'teste',
+        'senha': 'original'
+    })
+    assert resp.status_code == 201
+    user_id = resp.get_json()['id']
+
+    # login como o novo usuario
+    resp_login = client.post('/api/login', json={'username': 'teste', 'senha': 'original'})
+    assert resp_login.status_code == 200
+    token = resp_login.get_json()['token']
+    headers = {'Authorization': f'Bearer {token}'}
+
+    # Falta senha_atual
+    resp_put = client.put(f'/api/usuarios/{user_id}', json={'senha': 'nova'}, headers=headers)
+    assert resp_put.status_code == 400
+
+    # Senha atual incorreta
+    resp_put = client.put(
+        f'/api/usuarios/{user_id}',
+        json={'senha': 'nova', 'senha_atual': 'errada'},
+        headers=headers,
+    )
+    assert resp_put.status_code == 403
+
+    # Senha atual correta
+    resp_put = client.put(
+        f'/api/usuarios/{user_id}',
+        json={'senha': 'nova', 'senha_atual': 'original'},
+        headers=headers,
+    )
+    assert resp_put.status_code == 200
+
+    # login com nova senha deve funcionar
+    resp_login2 = client.post('/api/login', json={'username': 'teste', 'senha': 'nova'})
+    assert resp_login2.status_code == 200


### PR DESCRIPTION
## Summary
- enforce old password verification when updating user passwords
- send `senha_atual` in profile pages when changing passwords
- test password update requires the current password

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c11a4d8b08323b752311a88d97ac9