### PR TITLE
Add access control tests for non-admin users

### DIFF
--- a/tests/test_agendamento_routes.py
+++ b/tests/test_agendamento_routes.py
@@ -1,11 +1,15 @@
-from datetime import date
+from datetime import date, datetime, timedelta
+import jwt
+from src.models.user import User
+from src.routes.user import gerar_token_acesso, gerar_refresh_token
 
 
 def login_admin(client):
-    resp = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
-    assert resp.status_code == 200
-    data = resp.get_json()
-    return data['token'], data['refresh_token']
+    with client.application.app_context():
+        user = User.query.filter_by(username='admin').first()
+        token = gerar_token_acesso(user)
+        refresh = gerar_refresh_token(user)
+    return token, refresh
 
 
 def test_criar_e_listar_agendamento(client):

--- a/tests/test_export_routes.py
+++ b/tests/test_export_routes.py
@@ -14,6 +14,7 @@ from src.models.user import User
 from src.routes.user import user_bp
 from src.routes.agendamento import agendamento_bp
 from src.routes.ocupacao import ocupacao_bp
+from src.routes.user import gerar_token_acesso, gerar_refresh_token
 
 
 @pytest.fixture
@@ -40,10 +41,11 @@ def client_ag(app_agendamentos):
 
 
 def login_admin(client):
-    resp = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
-    assert resp.status_code == 200
-    data = resp.get_json()
-    return data['token'], data['refresh_token']
+    with client.application.app_context():
+        user = User.query.filter_by(username='admin').first()
+        token = gerar_token_acesso(user)
+        refresh = gerar_refresh_token(user)
+    return token, refresh
 
 
 def test_export_agendamentos_csv(client_ag):

--- a/tests/test_instrutor_routes.py
+++ b/tests/test_instrutor_routes.py
@@ -1,0 +1,30 @@
+import jwt
+from datetime import datetime, timedelta
+from src.models.user import User
+
+
+def admin_headers(app):
+    with app.app_context():
+        user = User.query.filter_by(username='admin').first()
+        token = jwt.encode(
+            {
+                'user_id': user.id,
+                'nome': user.nome,
+                'perfil': user.tipo,
+                'exp': datetime.utcnow() + timedelta(hours=1),
+            },
+            app.config['SECRET_KEY'],
+            algorithm='HS256',
+        )
+        return {'Authorization': f'Bearer {token}'}
+
+
+def test_delete_instrutor_as_non_admin_fails(client, app, non_admin_auth_headers):
+    headers = admin_headers(app)
+    resp = client.post('/api/instrutores', json={'nome': 'Instrutor'}, headers=headers)
+    assert resp.status_code == 201
+    instrutor_id = resp.get_json()['id']
+
+    resp_del = client.delete(f'/api/instrutores/{instrutor_id}', headers=non_admin_auth_headers)
+    assert resp_del.status_code == 403
+

--- a/tests/test_sala_routes.py
+++ b/tests/test_sala_routes.py
@@ -1,9 +1,16 @@
 
+import jwt
+from datetime import datetime, timedelta
+from src.models.user import User
+from src.routes.user import gerar_token_acesso, gerar_refresh_token
+
+
 def login_admin(client):
-    resp = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
-    assert resp.status_code == 200
-    data = resp.get_json()
-    return data['token'], data['refresh_token']
+    with client.application.app_context():
+        user = User.query.filter_by(username='admin').first()
+        token = gerar_token_acesso(user)
+        refresh = gerar_refresh_token(user)
+    return token, refresh
 
 
 def test_criar_e_listar_sala(client):
@@ -22,3 +29,27 @@ def test_criar_e_listar_sala(client):
     assert resp.status_code == 200
     salas = resp.get_json()
     assert any(s['id'] == sala_id for s in salas)
+
+
+def test_create_sala_as_non_admin_fails(client, non_admin_auth_headers):
+    response = client.post(
+        '/api/salas',
+        headers=non_admin_auth_headers,
+        json={'nome': 'Sala Proibida', 'capacidade': 5},
+    )
+    assert response.status_code == 403
+
+
+def test_delete_sala_as_non_admin_fails(client, non_admin_auth_headers):
+    token, _ = login_admin(client)
+    admin_headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post(
+        '/api/salas',
+        json={'nome': 'Sala Delete', 'capacidade': 5},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    sala_id = resp.get_json()['id']
+
+    delete_resp = client.delete(f'/api/salas/{sala_id}', headers=non_admin_auth_headers)
+    assert delete_resp.status_code == 403

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -1,9 +1,16 @@
 
+import jwt
+from datetime import datetime, timedelta
+from src.models.user import User
+from src.routes.user import gerar_token_acesso, gerar_refresh_token
+
+
 def login_admin(client):
-    response = client.post('/api/login', json={'username': 'admin', 'senha': 'password'})
-    assert response.status_code == 200
-    data = response.get_json()
-    return data['token'], data['refresh_token']
+    with client.application.app_context():
+        user = User.query.filter_by(username='admin').first()
+        token = gerar_token_acesso(user)
+        refresh = gerar_refresh_token(user)
+    return token, refresh
 
 
 def test_criar_usuario(client):


### PR DESCRIPTION
## Summary
- add instrutor blueprint and non-admin fixtures
- test access restrictions for Sala and Instrutor endpoints
- avoid login route rate limit by generating tokens directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7722803083239709d3df51980af2