### PR TITLE
Add Docker containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.venv
+__pycache__/
+*.pyc
+.pytest_cache/
+.dockerignore
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Usar uma imagem base oficial e slim para menor tamanho
+FROM python:3.11-slim
+
+# Definir variáveis de ambiente para Python e Poetry
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=false \
+    POETRY_VIRTUALENVS_CREATE=false
+
+# Definir o diretório de trabalho
+WORKDIR /app
+
+# Instalar o Poetry
+RUN pip install poetry
+
+# Copiar apenas os arquivos de dependência primeiro para aproveitar o cache do Docker
+COPY poetry.lock pyproject.toml ./
+
+# Instalar as dependências de produção
+RUN poetry install --no-root --no-dev
+
+# Copiar o restante do código-fonte da aplicação
+COPY ./src ./src
+
+# Expor a porta que o Gunicorn usará
+EXPOSE 8000
+
+# Comando para iniciar a aplicação
+CMD ["poetry", "run", "gunicorn", "--bind", "0.0.0.0:8000", "src.main:create_app()"]

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ Consulte o arquivo [CHANGELOG.md](CHANGELOG.md) para detalhes das versões.
 
 5. As rotas de autenticação e cadastro possuem uma limitação de
    requisições por minuto para evitar abusos de login ou criação de contas.
+
+## Usando Docker
+
+Uma alternativa é rodar a aplicação em um container Docker. Para construir a imagem execute:
+
+```bash
+docker build -t agenda-senai .
+```
+
+Em seguida, inicie o container usando as variáveis definidas em um arquivo `.env`:
+
+```bash
+docker run -p 8000:8000 --env-file .env agenda-senai
+```
+
+A aplicação ficará disponível em [http://localhost:8000](http://localhost:8000).


### PR DESCRIPTION
## Summary
- ignore development files for Docker
- add Dockerfile to build the application image
- document how to build and run the container with Docker

## Testing
- `pip install -r requirements.lock`
- `pytest -q`
- `docker build -t agenda-senai .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8f0d99e08323bf8050769cdeae88