### PR TITLE
Fix poetry install flag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install poetry
 COPY poetry.lock pyproject.toml ./
 
 # Instalar as dependências de produção
-RUN poetry install --no-root --no-dev
+RUN poetry install --no-root --without dev
 
 # Copiar o restante do código-fonte da aplicação
 COPY ./src ./src


### PR DESCRIPTION
## Summary
- fix Docker build by replacing the deprecated `--no-dev` option

## Testing
- `pip install -r requirements.lock`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c900afe6c8323a76a5e7dcea1684f