### PR TITLE
Add loading states and toast notifications

### DIFF
--- a/src/static/admin-login.html
+++ b/src/static/admin-login.html
@@ -41,8 +41,9 @@
                             </div>
                             
                             <div class="d-grid gap-2">
-                                <button class="btn btn-primary" type="submit">
-                                    <i class="bi bi-box-arrow-in-right me-2"></i>Entrar
+                                <button class="btn btn-primary" type="submit" id="btnLogin">
+                                    <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                                    <span class="btn-text"><i class="bi bi-box-arrow-in-right me-2"></i>Entrar</span>
                                 </button>
                             </div>
                         </form>
@@ -80,7 +81,11 @@
             const loginForm = document.getElementById('loginForm');
             loginForm.addEventListener('submit', async function(e) {
                 e.preventDefault();
-                
+                const btn = document.getElementById('btnLogin');
+                const spinner = btn.querySelector('.spinner-border');
+                btn.disabled = true;
+                spinner.classList.remove('d-none');
+
                 const username = document.getElementById('username').value;
                 const senha = document.getElementById('senha').value;
                 
@@ -90,9 +95,15 @@
                     await realizarLogin(username, senha);
                 } catch (error) {
                     exibirAlerta('Credenciais inválidas. Por favor, tente novamente.', 'danger');
+                } finally {
+                    btn.disabled = false;
+                    spinner.classList.add('d-none');
                 }
             });
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/calendario-salas.html
+++ b/src/static/calendario-salas.html
@@ -314,6 +314,9 @@
             aplicarFiltrosURL();
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>
 

--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -274,5 +274,8 @@
             configurarFiltros();
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/dashboard-salas.html
+++ b/src/static/dashboard-salas.html
@@ -417,6 +417,9 @@
             carregarTendenciaMensal();
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>
 

--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -301,9 +301,9 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="button" class="btn btn-primary" onclick="salvarInstrutor()">
-                        <i class="bi bi-check-circle me-1"></i>
-                        <span id="btnSalvarTexto">Salvar</span>
+                    <button type="submit" form="formInstrutor" class="btn btn-primary" id="btnSalvarInstrutor">
+                        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                        <span class="btn-text"><i class="bi bi-check-circle me-1"></i><span id="btnSalvarTexto">Salvar</span></span>
                     </button>
                 </div>
             </div>
@@ -378,6 +378,9 @@
             modalElem.addEventListener('hidden.bs.modal', novoInstrutor);
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>
 

--- a/src/static/gerenciar-salas.html
+++ b/src/static/gerenciar-salas.html
@@ -269,9 +269,9 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="button" class="btn btn-primary" onclick="salvarSala()">
-                        <i class="bi bi-check-circle me-1"></i>
-                        <span id="btnSalvarTexto">Salvar</span>
+                    <button type="submit" form="formSala" class="btn btn-primary" id="btnSalvarSala">
+                        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                        <span class="btn-text"><i class="bi bi-check-circle me-1"></i><span id="btnSalvarTexto">Salvar</span></span>
                     </button>
                 </div>
             </div>
@@ -332,6 +332,9 @@
             modalElem.addEventListener('hidden.bs.modal', novaSala);
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>
 

--- a/src/static/gerenciar-turmas.html
+++ b/src/static/gerenciar-turmas.html
@@ -133,7 +133,8 @@
                             </div>
                             <div class="col-md-4 d-flex align-items-end">
                                 <button type="submit" class="btn btn-primary w-100" id="btnSalvarTurma">
-                                    <i class="bi bi-plus-circle me-2"></i>Adicionar
+                                    <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                                    <span class="btn-text"><i class="bi bi-plus-circle me-2"></i>Adicionar</span>
                                 </button>
                             </div>
                         </form>
@@ -202,5 +203,8 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/turmas.js"></script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -458,5 +458,8 @@
             }
         }
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -277,28 +277,34 @@ function formatarHorario(horario) {
  * @param {string} containerId - ID do container onde o alerta será exibido
  */
 function exibirAlerta(mensagem, tipo = 'info', containerId = 'alertContainer') {
-    const container = document.getElementById(containerId);
-    if (!container) return;
+    const toastContainer = document.querySelector('.toast-container');
+    if (!toastContainer) return;
 
-    const alertDiv = document.createElement('div');
-    alertDiv.className = `alert alert-${tipo} alert-dismissible fade show`;
-    alertDiv.role = 'alert';
+    const toastId = `toast-${Date.now()}`;
+    const bgColor =
+        tipo === 'danger' ? 'bg-danger' :
+        (tipo === 'success' ? 'bg-success' : 'bg-primary');
 
-    alertDiv.textContent = mensagem;
-    const closeBtn = document.createElement('button');
-    closeBtn.type = 'button';
-    closeBtn.className = 'btn-close';
-    closeBtn.setAttribute('data-bs-dismiss', 'alert');
-    closeBtn.setAttribute('aria-label', 'Fechar');
-    alertDiv.appendChild(closeBtn);
+    const toastHtml = `
+        <div id="${toastId}" class="toast text-white ${bgColor}" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="5000">
+            <div class="d-flex">
+                <div class="toast-body">
+                    ${escapeHTML(mensagem)}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>`;
 
-    container.appendChild(alertDiv);
-    
-    // Remove o alerta após 5 segundos
-    setTimeout(() => {
-        alertDiv.classList.remove('show');
-        setTimeout(() => alertDiv.remove(), 150);
-    }, 5000);
+    toastContainer.insertAdjacentHTML('beforeend', toastHtml);
+
+    const toastElement = document.getElementById(toastId);
+    const toast = new bootstrap.Toast(toastElement);
+
+    toastElement.addEventListener('hidden.bs.toast', () => {
+        toastElement.remove();
+    });
+
+    toast.show();
 }
 
 /**

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -402,6 +402,12 @@ class GerenciadorInstrutores {
 
 // Salva instrutor (criar ou atualizar)
     async salvarInstrutor() {
+    const btn = document.getElementById('btnSalvarInstrutor');
+    const spinner = btn ? btn.querySelector('.spinner-border') : null;
+    if (btn && spinner) {
+        btn.disabled = true;
+        spinner.classList.remove('d-none');
+    }
     try {
         const formData = {
             nome: document.getElementById('instrutorNome').value.trim(),
@@ -457,6 +463,11 @@ class GerenciadorInstrutores {
     } catch (error) {
         console.error('Erro ao salvar instrutor:', error);
         exibirAlerta(error.message, 'danger');
+    } finally {
+        if (btn && spinner) {
+            btn.disabled = false;
+            spinner.classList.add('d-none');
+        }
     }
 }
 

--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -254,6 +254,12 @@ class GerenciadorSalas {
 
 // Salva sala (criar ou atualizar)
     async salvarSala() {
+    const btn = document.getElementById('btnSalvarSala');
+    const spinner = btn ? btn.querySelector('.spinner-border') : null;
+    if (btn && spinner) {
+        btn.disabled = true;
+        spinner.classList.remove('d-none');
+    }
     try {
         const formData = {
             nome: document.getElementById('salaNome').value.trim(),
@@ -316,6 +322,11 @@ class GerenciadorSalas {
     } catch (error) {
         console.error('Erro ao salvar sala:', error);
         exibirAlerta(error.message, 'danger');
+    } finally {
+        if (btn && spinner) {
+            btn.disabled = false;
+            spinner.classList.add('d-none');
+        }
     }
 }
 

--- a/src/static/js/turmas.js
+++ b/src/static/js/turmas.js
@@ -42,6 +42,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     async function salvarTurma() {
+        const btn = document.getElementById('btnSalvarTurma');
+        const spinner = btn ? btn.querySelector('.spinner-border') : null;
+        if (btn && spinner) {
+            btn.disabled = true;
+            spinner.classList.remove('d-none');
+        }
         const id = document.getElementById('turmaId').value;
         const nome = document.getElementById('nomeTurma').value;
 
@@ -65,6 +71,11 @@ document.addEventListener('DOMContentLoaded', () => {
             carregarTurmas();
         } catch (error) {
             exibirAlerta(`Erro ao salvar turma: ${error.message}`, 'danger');
+        } finally {
+            if (btn && spinner) {
+                btn.disabled = false;
+                spinner.classList.add('d-none');
+            }
         }
     }
 

--- a/src/static/laboratorios-turmas.html
+++ b/src/static/laboratorios-turmas.html
@@ -455,5 +455,8 @@
             }
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/novo-agendamento-sala.html
+++ b/src/static/novo-agendamento-sala.html
@@ -233,6 +233,9 @@
             adicionarListenersValidacao();
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>
 

--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -567,5 +567,8 @@
             }
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/perfil-salas.html
+++ b/src/static/perfil-salas.html
@@ -331,5 +331,8 @@
             }
         }
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/perfil-usuarios.html
+++ b/src/static/perfil-usuarios.html
@@ -276,5 +276,8 @@
         }
         
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/perfil.html
+++ b/src/static/perfil.html
@@ -307,5 +307,8 @@
             }
         }
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/register.html
+++ b/src/static/register.html
@@ -68,8 +68,9 @@
                             </div>
                             
                             <div class="d-grid gap-2">
-                                <button class="btn btn-primary" type="submit">
-                                    <i class="bi bi-person-plus me-2"></i>Registrar
+                                <button class="btn btn-primary" type="submit" id="btnRegistrar">
+                                    <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                                    <span class="btn-text"><i class="bi bi-person-plus me-2"></i>Registrar</span>
                                 </button>
                             </div>
                         </form>
@@ -116,7 +117,11 @@
             const registerForm = document.getElementById('registerForm');
             registerForm.addEventListener('submit', async function(e) {
                 e.preventDefault();
-                
+                const btn = document.getElementById('btnRegistrar');
+                const spinner = btn.querySelector('.spinner-border');
+                btn.disabled = true;
+                spinner.classList.remove('d-none');
+
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
                 const username = document.getElementById('username').value;
@@ -150,9 +155,15 @@
                     }, 2000);
                 } catch (error) {
                     exibirAlerta(`Erro ao registrar: ${error.message}`, 'danger');
+                } finally {
+                    btn.disabled = false;
+                    spinner.classList.add('d-none');
                 }
             });
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -131,5 +131,8 @@
             });
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/usuarios.html
+++ b/src/static/usuarios.html
@@ -368,5 +368,8 @@
             });
         });
     </script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add loading spinners to form buttons and disable during requests
- refactor `exibirAlerta` to use Bootstrap Toasts
- include toast container across pages for notifications
- update page scripts to toggle spinners on submit

## Testing
- `pip install -r requirements.lock`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c9578bedc83239e4ad5d72d260914