### PR TITLE
Fix missing instrutor helper references

### DIFF
--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -230,8 +230,8 @@ class GerenciadorInstrutores {
     tbody.innerHTML = '';
     
     instrutores.forEach(instrutor => {
-        const statusBadge = getStatusBadgeInstrutor(instrutor.status);
-        const areaNome = getAreaNome(instrutor.area_atuacao);
+        const statusBadge = this.getStatusBadgeInstrutor(instrutor.status);
+        const areaNome = this.getAreaNome(instrutor.area_atuacao);
         const capacidades = instrutor.capacidades.slice(0, 3).join(', ') + (instrutor.capacidades.length > 3 ? '...' : '');
         
         const row = document.createElement('tr');


### PR DESCRIPTION
## Summary
- reference instrutor helper methods with `this` for correct scope

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3b0243188323a9df1111bff57ed5