### PR TITLE
Fix getStatusBadge reference

### DIFF
--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -136,7 +136,7 @@ class GerenciadorSalas {
     tbody.innerHTML = '';
     
     salas.forEach(sala => {
-        const statusBadge = getStatusBadge(sala.status);
+        const statusBadge = this.getStatusBadge(sala.status);
         const recursos = sala.recursos.slice(0, 3).join(', ') + (sala.recursos.length > 3 ? '...' : '');
         
         const row = document.createElement('tr');


### PR DESCRIPTION
## Summary
- fix reference to `getStatusBadge` when rendering the salas table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_685dd1d6cf1483238fc6b352d46ba9ff