### PR TITLE
Fix non-array data issues in front-end

### DIFF
--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -232,7 +232,8 @@ class GerenciadorInstrutores {
     instrutores.forEach(instrutor => {
         const statusBadge = this.getStatusBadgeInstrutor(instrutor.status);
         const areaNome = this.getAreaNome(instrutor.area_atuacao);
-        const capacidades = instrutor.capacidades.slice(0, 3).join(', ') + (instrutor.capacidades.length > 3 ? '...' : '');
+        const capsLista = Array.isArray(instrutor.capacidades) ? instrutor.capacidades : [];
+        const capacidades = capsLista.slice(0, 3).join(', ') + (capsLista.length > 3 ? '...' : '');
         
         const row = document.createElement('tr');
         row.innerHTML = sanitizeHTML(`
@@ -366,7 +367,8 @@ class GerenciadorInstrutores {
         if (response.ok) {
             const instrutor = await response.json();
             this.instrutorEditando = instrutor;
-            this.capacidadesInstrutor = [...instrutor.capacidades];
+            const caps = Array.isArray(instrutor.capacidades) ? instrutor.capacidades : [];
+            this.capacidadesInstrutor = [...caps];
             
             // Preenche o formulário
             document.getElementById('modalInstrutorLabel').textContent = 'Editar Instrutor';
@@ -383,7 +385,7 @@ class GerenciadorInstrutores {
             this.renderizarCapacidades();
             
             // Preenche disponibilidade
-            const disponibilidade = instrutor.disponibilidade || [];
+            const disponibilidade = Array.isArray(instrutor.disponibilidade) ? instrutor.disponibilidade : [];
             document.getElementById('dispManha').checked = disponibilidade.includes('manha');
             document.getElementById('dispTarde').checked = disponibilidade.includes('tarde');
             document.getElementById('dispNoite').checked = disponibilidade.includes('noite');

--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -137,7 +137,8 @@ class GerenciadorSalas {
     
     salas.forEach(sala => {
         const statusBadge = this.getStatusBadge(sala.status);
-        const recursos = sala.recursos.slice(0, 3).join(', ') + (sala.recursos.length > 3 ? '...' : '');
+        const recursosLista = Array.isArray(sala.recursos) ? sala.recursos : [];
+        const recursos = recursosLista.slice(0, 3).join(', ') + (recursosLista.length > 3 ? '...' : '');
         
         const row = document.createElement('tr');
         row.innerHTML = sanitizeHTML(`
@@ -236,7 +237,8 @@ class GerenciadorSalas {
             this.recursosSala.forEach(recurso => {
                 const checkbox = document.getElementById(`recurso_${recurso.valor}`);
                 if (checkbox) {
-                    checkbox.checked = sala.recursos.includes(recurso.valor);
+                    const lista = Array.isArray(sala.recursos) ? sala.recursos : [];
+                    checkbox.checked = lista.includes(recurso.valor);
                 }
             });
             


### PR DESCRIPTION
## Summary
- handle cases where `sala.recursos` or `instrutor.capacidades` come as strings
- guard check when editing existing rooms and instructors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_685dd2e634d883239095c06d52532203