### PR TITLE
Atualiza layout da tabela de instrutores

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -182,9 +182,11 @@ small, .small {
 }
 
 /* Tabelas */
-.table thead th {
-  font-weight: bold;
-  font-size: 14px;
+.table > thead th {
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: #333;
 }
 
 .table tbody tr {
@@ -198,6 +200,14 @@ small, .small {
 .table .table-actions i {
   margin-right: 8px;
   cursor: pointer;
+}
+
+.btn-group .btn {
+  border-radius: 0 !important;
+}
+
+.btn-group > .btn:not(:last-child) {
+  border-right: none;
 }
 
 /* Calendário */

--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -178,19 +178,18 @@
                         
                         <div id="listaInstrutores" style="display: none;">
                             <div class="table-responsive">
-                                <table class="table table-hover">
+                                <table class="table table-striped table-hover">
                                     <thead class="table-light">
                                         <tr>
-                                            <th>Nome</th>
-                                            <th>Email</th>
-                                            <th>Área de Atuação</th>
-                                            <th>Status</th>
-                                            <th>Capacidades</th>
-                                            <th>Ações</th>
+                                            <th scope="col">Nome</th>
+                                            <th scope="col">Email</th>
+                                            <th scope="col">Área de Atuação</th>
+                                            <th scope="col">Status</th>
+                                            <th scope="col">Capacidades</th>
+                                            <th scope="col">Ações</th>
                                         </tr>
                                     </thead>
                                     <tbody id="tabelaInstrutores">
-                                        <!-- Conteúdo será preenchido via JavaScript -->
                                     </tbody>
                                 </table>
                             </div>

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -233,35 +233,31 @@ class GerenciadorInstrutores {
         const statusBadge = this.getStatusBadgeInstrutor(instrutor.status);
         const areaNome = this.getAreaNome(instrutor.area_atuacao);
         const capsLista = Array.isArray(instrutor.capacidades) ? instrutor.capacidades : [];
-        const capacidades = capsLista.slice(0, 3).join(', ') + (capsLista.length > 3 ? '...' : '');
-        
-        const row = document.createElement('tr');
-        row.innerHTML = sanitizeHTML(`
-            <td>
-                <strong>${escapeHTML(instrutor.nome)}</strong>
-                ${instrutor.telefone ? `<br><small class="text-muted">${escapeHTML(instrutor.telefone)}</small>` : ''}
-            </td>
-            <td>${escapeHTML(instrutor.email) || '-'}</td>
-            <td>${areaNome}</td>
-            <td>${statusBadge}</td>
-            <td>
-                <small class="text-muted">${capacidades || 'Nenhuma'}</small>
-            </td>
-            <td>
-                <div class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-primary" onclick="gerenciadorInstrutores.editarInstrutor(${instrutor.id})" title="Editar">
-                        <i class="bi bi-pencil"></i>
-                    </button>
-                    <button type="button" class="btn btn-outline-info" onclick="gerenciadorInstrutores.verOcupacoesInstrutor(${instrutor.id})" title="Ver Ocupações">
-                        <i class="bi bi-calendar-check"></i>
-                    </button>
-                    <button type="button" class="btn btn-outline-danger" onclick="gerenciadorInstrutores.excluirInstrutor(${instrutor.id}, '${instrutor.nome}')" title="Excluir">
-                        <i class="bi bi-trash"></i>
-                    </button>
-                </div>
-            </td>
-        `);
-        tbody.appendChild(row);
+        const capacidades = capsLista.slice(0, 2).join(', ') + (capsLista.length > 2 ? '...' : '');
+
+        const row = `
+            <tr>
+                <td><strong>${escapeHTML(instrutor.nome)}</strong>${instrutor.telefone ? `<br><small class="text-muted">${escapeHTML(instrutor.telefone)}</small>` : ''}</td>
+                <td>${escapeHTML(instrutor.email) || '-'}</td>
+                <td>${escapeHTML(areaNome)}</td>
+                <td>${statusBadge}</td>
+                <td><small class="text-muted">${escapeHTML(capacidades || 'Nenhuma')}</small></td>
+                <td>
+                    <div class="btn-group btn-group-sm" role="group">
+                        <button type="button" class="btn btn-outline-primary" onclick="gerenciadorInstrutores.editarInstrutor(${instrutor.id})" title="Editar">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-info" onclick="gerenciadorInstrutores.verOcupacoesInstrutor(${instrutor.id})" title="Ver Ocupações">
+                            <i class="bi bi-calendar-check"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-danger" onclick="gerenciadorInstrutores.excluirInstrutor(${instrutor.id}, '${escapeHTML(instrutor.nome)}')" title="Excluir">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </div>
+                </td>
+            </tr>
+        `;
+        tbody.insertAdjacentHTML('beforeend', sanitizeHTML(row));
     });
     }
 


### PR DESCRIPTION
## Summary
- refatora a lista de instrutores para usar `<table>` responsiva e alinhada
- ajusta renderização de linhas no JavaScript
- aplica melhorias visuais no CSS para cabeçalho e botões de ação

## Testing
- `pytest -q` *(falha: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_685dd53f5f80832384276b1a97d5d3d0