### PR TITLE
Refatora lista de instrutores para tabela semântica

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -189,6 +189,11 @@ small, .small {
   color: #333;
 }
 
+.table td,
+.table th {
+  vertical-align: middle;
+}
+
 .table tbody tr {
   min-height: 48px;
 }

--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -176,29 +176,20 @@
                             <p class="mt-2">Carregando instrutores...</p>
                         </div>
                         
-                        <div id="listaInstrutores" style="display: none;">
-                            <div class="table-responsive">
-                                <table class="table table-striped table-hover">
-                                    <thead class="table-light">
-                                        <tr>
-                                            <th scope="col">Nome</th>
-                                            <th scope="col">Email</th>
-                                            <th scope="col">Área de Atuação</th>
-                                            <th scope="col">Status</th>
-                                            <th scope="col">Capacidades</th>
-                                            <th scope="col">Ações</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody id="tabelaInstrutores">
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-
-                        <div id="nenhumInstrutor" style="display: none;" class="text-center py-4">
-                            <i class="bi bi-person-badge text-muted" style="font-size: 3rem;"></i>
-                            <h5 class="text-muted mt-3">Nenhum instrutor encontrado</h5>
-                            <p class="text-muted">Não há instrutores cadastrados ou que atendam aos filtros aplicados.</p>
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col">Nome</th>
+                                        <th scope="col">Email</th>
+                                        <th scope="col">Área de Atuação</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Capacidades</th>
+                                        <th scope="col">Ações</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="tabelaInstrutores"></tbody>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -161,8 +161,6 @@ class GerenciadorInstrutores {
     async carregarInstrutores() {
         try {
             document.getElementById('loadingInstrutores').style.display = 'block';
-            document.getElementById('listaInstrutores').style.display = 'none';
-            document.getElementById('nenhumInstrutor').style.display = 'none';
         
         // Constrói parâmetros de filtro
         const params = new URLSearchParams();
@@ -217,17 +215,14 @@ class GerenciadorInstrutores {
 // Renderiza a tabela de instrutores
     renderizarTabelaInstrutores(instrutores) {
         const tbody = document.getElementById('tabelaInstrutores');
-    
-    if (instrutores.length === 0) {
-        document.getElementById('listaInstrutores').style.display = 'none';
-        document.getElementById('nenhumInstrutor').style.display = 'block';
+
+    tbody.innerHTML = '';
+
+    if (!instrutores || instrutores.length === 0) {
+        const colCount = 6;
+        tbody.innerHTML = `<tr><td colspan="${colCount}" class="text-center">Nenhum instrutor encontrado.</td></tr>`;
         return;
     }
-    
-    document.getElementById('listaInstrutores').style.display = 'block';
-    document.getElementById('nenhumInstrutor').style.display = 'none';
-    
-    tbody.innerHTML = '';
     
     instrutores.forEach(instrutor => {
         const statusBadge = this.getStatusBadgeInstrutor(instrutor.status);


### PR DESCRIPTION
## Summary
- remove container de mensagens e usar linha na tabela
- simplificar lógica de exibição no JS
- alinhar células da tabela no CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_685dd7a439048323aabd4da291858711