### PR TITLE
Fix instructor table layout

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -242,6 +242,10 @@ small, .small {
   padding: 0.25rem 0.4rem;
 }
 
+#tabelaInstrutores td.text-truncate {
+  max-width: 200px;
+}
+
 /* Calendário */
 .calendario-container {
   background-color: #fff;

--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -177,7 +177,7 @@
                         </div>
                         
                         <div class="table-responsive">
-                            <table class="table table-striped table-hover">
+                            <table class="table table-striped table-hover align-middle">
                                 <thead class="table-light">
                                     <tr>
                                         <th scope="col">Nome</th>

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -232,13 +232,13 @@ class GerenciadorInstrutores {
 
         const row = `
             <tr>
-                <td>
+                <td class="text-truncate" style="max-width: 200px;">
                     <strong>${escapeHTML(instrutor.nome)}</strong><br>
                     <small class="text-muted">${escapeHTML(instrutor.email || '-')}</small>
                 </td>
-                <td>${escapeHTML(areaNome)}</td>
+                <td class="text-truncate" style="max-width: 150px;">${escapeHTML(areaNome)}</td>
                 <td>${statusBadge}</td>
-                <td><small class="text-muted">${escapeHTML(capacidades || 'Nenhuma')}</small></td>
+                <td class="text-truncate" style="max-width: 200px;"><small class="text-muted">${escapeHTML(capacidades || 'Nenhuma')}</small></td>
                 <td>
                     <div class="btn-group btn-group-sm" role="group">
                         <button type="button" class="btn btn-outline-primary" onclick="gerenciadorInstrutores.editarInstrutor(${instrutor.id})" title="Editar">


### PR DESCRIPTION
## Summary
- adjust table markup to use Bootstrap's `align-middle`
- truncate long fields in instructor rows
- set max-width for truncated columns in CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_685ddd72b9348323a4ab0db503f7c385