### PR TITLE
Padroniza gerenciamento de instrutores e salas

### DIFF
--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -105,14 +105,11 @@
 
             <!-- Conteúdo Principal -->
             <main class="col-lg-9">
-                <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                    <h1 class="h2">Gerenciar Instrutores</h1>
-                    <div class="btn-toolbar mb-2 mb-md-0">
-                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalInstrutor" onclick="gerenciadorInstrutores.novoInstrutor()">
-                            <i class="bi bi-plus-circle me-1"></i>
-                            Novo Instrutor
-                        </button>
-                    </div>
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h2 class="mb-0">Gerenciar Instrutores</h2>
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalInstrutor" onclick="gerenciadorInstrutores.novoInstrutor()">
+                        <i class="bi bi-plus-circle me-2"></i>Adicionar
+                    </button>
                 </div>
 
                 <!-- Filtros -->
@@ -181,6 +178,7 @@
                                 <thead class="table-light">
                                     <tr>
                                         <th scope="col">Nome</th>
+                                        <th scope="col">Email</th>
                                         <th scope="col">Área de Atuação</th>
                                         <th scope="col">Status</th>
                                         <th scope="col">Capacidades</th>

--- a/src/static/gerenciar-salas.html
+++ b/src/static/gerenciar-salas.html
@@ -105,14 +105,11 @@
 
             <!-- Conteúdo Principal -->
             <main class="col-lg-9">
-                <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                    <h1 class="h2">Gerenciar Salas</h1>
-                    <div class="btn-toolbar mb-2 mb-md-0">
-                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalSala" onclick="novaSala()">
-                            <i class="bi bi-plus-circle me-1"></i>
-                            Nova Sala
-                        </button>
-                    </div>
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h2 class="mb-0">Gerenciar Salas</h2>
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalSala" onclick="novaSala()">
+                        <i class="bi bi-plus-circle me-2"></i>Adicionar
+                    </button>
                 </div>
 
                 <!-- Filtros -->
@@ -172,14 +169,14 @@
                         
                         <div id="listaSalas" style="display: none;">
                             <div class="table-responsive">
-                                <table class="table table-hover">
+                                <table class="table table-striped table-hover">
                                     <thead class="table-light">
                                         <tr>
+                                            <th>ID</th>
                                             <th>Nome</th>
+                                            <th>Tipo</th>
                                             <th>Capacidade</th>
-                                            <th>Localização</th>
                                             <th>Status</th>
-                                            <th>Recursos</th>
                                             <th>Ações</th>
                                         </tr>
                                     </thead>

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -219,7 +219,7 @@ class GerenciadorInstrutores {
     tbody.innerHTML = '';
 
     if (!instrutores || instrutores.length === 0) {
-        const colCount = 5;
+        const colCount = 6;
         tbody.innerHTML = `<tr><td colspan="${colCount}" class="text-center">Nenhum instrutor encontrado.</td></tr>`;
         return;
     }
@@ -232,11 +232,8 @@ class GerenciadorInstrutores {
 
         const row = `
             <tr>
-                <td class="text-truncate" style="max-width: 200px;">
-                    <strong>${escapeHTML(instrutor.nome)}</strong><br>
-                    <small>${escapeHTML(instrutor.email || '-')}</small><br>
-                    <small class="text-muted">${escapeHTML(areaNome)}</small>
-                </td>
+                <td class="text-truncate" style="max-width: 200px;">${escapeHTML(instrutor.nome)}</td>
+                <td class="text-truncate" style="max-width: 200px;">${escapeHTML(instrutor.email || '-')}</td>
                 <td class="text-truncate" style="max-width: 150px;">${escapeHTML(areaNome)}</td>
                 <td>${statusBadge}</td>
                 <td class="text-truncate" style="max-width: 200px;"><small class="text-muted">${escapeHTML(capacidades || 'Nenhuma')}</small></td>

--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -137,30 +137,18 @@ class GerenciadorSalas {
     
     salas.forEach(sala => {
         const statusBadge = this.getStatusBadge(sala.status);
-        const recursosLista = Array.isArray(sala.recursos) ? sala.recursos : [];
-        const recursos = recursosLista.slice(0, 3).join(', ') + (recursosLista.length > 3 ? '...' : '');
-        
+
         const row = document.createElement('tr');
         row.innerHTML = sanitizeHTML(`
-            <td>
-                <strong>${escapeHTML(sala.nome)}</strong>
-                ${sala.localizacao ? `<br><small class="text-muted">${escapeHTML(sala.localizacao)}</small>` : ''}
-            </td>
-            <td>
-                <span class="badge bg-info">${escapeHTML(sala.capacidade)} pessoas</span>
-            </td>
-            <td>${escapeHTML(sala.localizacao) || '-'}</td>
+            <td>${sala.id}</td>
+            <td class="text-truncate" style="max-width: 200px;">${escapeHTML(sala.nome)}</td>
+            <td class="text-truncate" style="max-width: 150px;">${escapeHTML(sala.tipo || '-')}</td>
+            <td>${escapeHTML(String(sala.capacidade))}</td>
             <td>${statusBadge}</td>
-            <td>
-                <small class="text-muted">${recursos || 'Nenhum'}</small>
-            </td>
             <td>
                 <div class="btn-group btn-group-sm" role="group">
                     <button type="button" class="btn btn-outline-primary" onclick="gerenciadorSalas.editarSala(${sala.id})" title="Editar">
                         <i class="bi bi-pencil"></i>
-                    </button>
-                    <button type="button" class="btn btn-outline-info" onclick="gerenciadorSalas.verOcupacoesSala(${sala.id})" title="Ver Ocupações">
-                        <i class="bi bi-calendar-check"></i>
                     </button>
                     <button type="button" class="btn btn-outline-danger" onclick="gerenciadorSalas.excluirSala(${sala.id}, '${sala.nome}')" title="Excluir">
                         <i class="bi bi-trash"></i>


### PR DESCRIPTION
## Summary
- padroniza cabeçalho das páginas de gerência
- ajusta tabelas de instrutores e salas conforme layout de turmas
- atualiza scripts JS de renderização das tabelas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_685de2eb51788323af2a10dfec1765f1