### PR TITLE
Corrigir listagem de instrutores em tabela

### DIFF
--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -165,16 +165,16 @@
                             <i class="bi bi-list me-2"></i>Lista de Instrutores
                         </h5>
                     </div>
-                    <div class="card-body">
+                    <div class="card-body p-0">
                         <div id="loadingInstrutores" class="text-center py-4">
                             <div class="spinner-border text-primary" role="status">
                                 <span class="visually-hidden">Carregando...</span>
                             </div>
                             <p class="mt-2">Carregando instrutores...</p>
                         </div>
-                        
+
                         <div class="table-responsive">
-                            <table class="table table-striped table-hover align-middle">
+                            <table class="table table-striped table-hover mb-0">
                                 <thead class="table-light">
                                     <tr>
                                         <th scope="col">Nome</th>

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -219,11 +219,11 @@ class GerenciadorInstrutores {
     tbody.innerHTML = '';
 
     if (!instrutores || instrutores.length === 0) {
-        const colCount = 6;
-        tbody.innerHTML = `<tr><td colspan="${colCount}" class="text-center">Nenhum instrutor encontrado.</td></tr>`;
+        const colCount = tbody.closest('table').querySelector('thead tr').childElementCount;
+        tbody.innerHTML = `<tr><td colspan="${colCount}" class="text-center py-4">Nenhum instrutor encontrado.</td></tr>`;
         return;
     }
-    
+
     instrutores.forEach(instrutor => {
         const statusBadge = this.getStatusBadgeInstrutor(instrutor.status);
         const areaNome = this.getAreaNome(instrutor.area_atuacao);
@@ -232,19 +232,15 @@ class GerenciadorInstrutores {
 
         const row = document.createElement('tr');
         row.innerHTML = sanitizeHTML(`
-            <td class="text-truncate" style="max-width: 200px;">${escapeHTML(instrutor.nome)}</td>
-            <td class="text-truncate" style="max-width: 200px;">${escapeHTML(instrutor.email || '-')}</td>
-            <td class="text-truncate" style="max-width: 150px;">${escapeHTML(areaNome)}</td>
+            <td><strong>${escapeHTML(instrutor.nome)}</strong></td>
+            <td>${escapeHTML(instrutor.email || '-')}</td>
+            <td>${escapeHTML(areaNome)}</td>
             <td>${statusBadge}</td>
-            <td class="text-truncate" style="max-width: 200px;"><small class="text-muted">${escapeHTML(capacidades || 'Nenhuma')}</small></td>
+            <td><small class="text-muted">${escapeHTML(capacidades || 'Nenhuma')}</small></td>
             <td>
                 <div class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-primary" onclick="gerenciadorInstrutores.editarInstrutor(${instrutor.id})" title="Editar">
-                        <i class="bi bi-pencil"></i>
-                    </button>
-                    <button type="button" class="btn btn-outline-danger" onclick="gerenciadorInstrutores.excluirInstrutor(${instrutor.id}, '${escapeHTML(instrutor.nome)}')" title="Excluir">
-                        <i class="bi bi-trash"></i>
-                    </button>
+                    <button type="button" class="btn btn-outline-primary" title="Editar" onclick="gerenciadorInstrutores.editarInstrutor(${instrutor.id})"><i class="bi bi-pencil"></i></button>
+                    <button type="button" class="btn btn-outline-danger" title="Excluir" onclick="gerenciadorInstrutores.excluirInstrutor(${instrutor.id}, '${escapeHTML(instrutor.nome)}')"><i class="bi bi-trash"></i></button>
                 </div>
             </td>
         `);


### PR DESCRIPTION
## Summary
- ajustar a tabela de instrutores para seguir layout semântico
- refatorar renderização no JavaScript

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_685f3487db7483238aae7670184770b2