### PR TITLE
Fix validation error display for salas

### DIFF
--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -316,10 +316,12 @@ class GerenciadorSalas {
                 mensagemErro = 'Erro de validação: ' + result.detail
                     .map(e => `Campo '${e.loc.join('.')}' - ${e.msg}`)
                     .join('; ');
-            } else if (result.detail) {
+            } else if (typeof result.detail === 'string') {
                 mensagemErro = result.detail;
             } else if (result.erro) {
                 mensagemErro = result.erro;
+            } else if (result.message) {
+                mensagemErro = result.message;
             }
 
             throw new Error(mensagemErro);


### PR DESCRIPTION
## Summary
- handle result.message when saving salas so `[object Object]` never appears

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6862e5ae8b1083238e9d6e9de3d64247