### PR TITLE
Fix sala edit error handling

### DIFF
--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -318,7 +318,11 @@ class GerenciadorSalas {
                     .join('; ');
             } else if (typeof result.detail === 'string') {
                 mensagemErro = result.detail;
-            } else if (result.erro) {
+            } else if (Array.isArray(result.erro)) {
+                mensagemErro = 'Erro de validação: ' + result.erro
+                    .map(e => `Campo '${e.loc.join('.')}' - ${e.msg}`)
+                    .join('; ');
+            } else if (typeof result.erro === 'string') {
                 mensagemErro = result.erro;
             } else if (result.message) {
                 mensagemErro = result.message;


### PR DESCRIPTION
## Summary
- properly handle validation errors returned from the API when editing salas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6862e70ce7688323a45463a1d5c67c7a