### PR TITLE
Fix room edit validation and logout with expired token

### DIFF
--- a/src/schemas/sala.py
+++ b/src/schemas/sala.py
@@ -11,10 +11,10 @@ class SalaCreateSchema(BaseModel):
     observacoes: Optional[str] = None
 
 class SalaUpdateSchema(BaseModel):
-    nome: Optional[str]
+    nome: Optional[str] = None
     capacidade: Optional[int] = Field(default=None, gt=0)
-    recursos: Optional[List[str]]
-    localizacao: Optional[str]
-    tipo: Optional[str]
-    status: Optional[str]
-    observacoes: Optional[str]
+    recursos: Optional[List[str]] = None
+    localizacao: Optional[str] = None
+    tipo: Optional[str] = None
+    status: Optional[str] = None
+    observacoes: Optional[str] = None


### PR DESCRIPTION
## Summary
- allow partial updates in `SalaUpdateSchema`
- permit logout with expired access tokens and without Authorization header
- test logout using an expired token

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6862ed2235188323899b33bbf07551c1