### PR TITLE
Fix room table column

### DIFF
--- a/src/static/gerenciar-salas.html
+++ b/src/static/gerenciar-salas.html
@@ -171,7 +171,7 @@
                                     <tr>
                                         <th scope="col">ID</th>
                                         <th scope="col">NOME</th>
-                                        <th scope="col">TIPO</th>
+                                        <th scope="col">RECURSOS DISPONÍVEIS</th>
                                         <th scope="col">CAPACIDADE</th>
                                         <th scope="col">STATUS</th>
                                         <th scope="col">AÇÕES</th>

--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -145,7 +145,7 @@ class GerenciadorSalas {
             <tr>
                 <td>${sala.id}</td>
                 <td><strong>${escapeHTML(sala.nome)}</strong></td>
-                <td>${escapeHTML(sala.tipo || '-')}</td>
+                <td>${Array.isArray(sala.recursos) && sala.recursos.length > 0 ? sala.recursos.map(r => escapeHTML(r)).join(', ') : '-'}</td>
                 <td>${sala.capacidade}</td>
                 <td>${statusBadge}</td>
                 <td>


### PR DESCRIPTION
## Summary
- show resources in the rooms list instead of deprecated type column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68632099c9988323b2748a2542eedf83