### PR TITLE
Fix redirect loop on login page

### DIFF
--- a/src/static/admin-login.html
+++ b/src/static/admin-login.html
@@ -66,8 +66,9 @@
     <script src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Redireciona para o dashboard se já estiver autenticado
-            if (estaAutenticado()) {
+            // Redireciona para o dashboard se já houver um token válido
+            const token = getToken();
+            if (token && !tokenExpirado(token)) {
                 const usuario = getUsuarioLogado();
                 if (usuario && usuario.tipo === 'admin') {
                     window.location.href = '/selecao-sistema.html';

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -186,6 +186,33 @@ function verificarPermissaoAdmin() {
     return true;
 }
 
+// ---------- Proteção de Rotas Global ----------
+// Esta IIFE garante que o redirecionamento ocorra apenas quando necessário,
+// evitando loops na página de login ou registro.
+(function() {
+    const currentPage = window.location.pathname;
+    const loginPage = '/admin-login.html';
+    const registerPage = '/register.html';
+    const token = getToken();
+
+    if (token && !tokenExpirado(token)) {
+        // Se estiver autenticado e na página pública, envia para o dashboard adequado
+        if (currentPage === loginPage || currentPage === registerPage) {
+            const usuario = getUsuarioLogado();
+            if (usuario && usuario.tipo === 'admin') {
+                window.location.href = '/selecao-sistema.html';
+            } else {
+                window.location.href = '/index.html';
+            }
+        }
+    } else {
+        // Não autenticado: redireciona para o login caso tente acessar página protegida
+        if (currentPage !== loginPage && currentPage !== registerPage) {
+            window.location.href = loginPage;
+        }
+    }
+})();
+
 // Funções para chamadas à API
 /**
  * Realiza uma chamada à API com autenticação

--- a/src/static/register.html
+++ b/src/static/register.html
@@ -93,8 +93,9 @@
     <script src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Redireciona para o dashboard se já estiver autenticado
-            if (estaAutenticado()) {
+            // Redireciona para o dashboard se já houver um token válido
+            const token = getToken();
+            if (token && !tokenExpirado(token)) {
                 window.location.href = '/index.html';
                 return;
             }


### PR DESCRIPTION
## Summary
- add global route guard to `app.js`
- update login page to check token without side effects
- update register page to check token without side effects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6863288aa57883238dd19153c1fe0dff