### PR TITLE
Fix turma update bug

### DIFF
--- a/src/routes/turma.py
+++ b/src/routes/turma.py
@@ -50,7 +50,7 @@ def criar_turma():
     if not verificar_admin(user):
         return jsonify({'erro': 'Permissão negada'}), 403
     
-    data = request.json
+    data = request.json or {}
 
     nome = (data.get('nome') or '').strip()
 
@@ -90,7 +90,7 @@ def atualizar_turma(id):
     if not turma:
         return jsonify({'erro': 'Turma não encontrada'}), 404
     
-    data = request.json
+    data = request.json or {}
 
     nome = (data.get('nome') or '').strip()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from src.models.user import User
 from src.models.sala import Sala
 from src.routes.user import user_bp
 from src.routes.sala import sala_bp
+from src.routes.turma import turma_bp
 from src.routes.agendamento import agendamento_bp
 from src.routes.instrutor import instrutor_bp
 
@@ -26,6 +27,7 @@ def app():
     db.init_app(app)
     app.register_blueprint(user_bp, url_prefix='/api')
     app.register_blueprint(sala_bp, url_prefix='/api')
+    app.register_blueprint(turma_bp, url_prefix='/api')
     app.register_blueprint(agendamento_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
 

--- a/tests/test_turma_routes.py
+++ b/tests/test_turma_routes.py
@@ -1,0 +1,41 @@
+import jwt
+from datetime import datetime, timedelta
+from src.models.user import User
+from src.routes.user import gerar_token_acesso, gerar_refresh_token
+
+
+def login_admin(client):
+    with client.application.app_context():
+        user = User.query.filter_by(username='admin').first()
+        token = gerar_token_acesso(user)
+        refresh = gerar_refresh_token(user)
+    return token, refresh
+
+
+def test_criar_e_atualizar_turma(client):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+
+    resp = client.post('/api/turmas', json={'nome': 'Turma1'}, headers=headers)
+    assert resp.status_code == 201
+    turma_id = resp.get_json()['id']
+
+    resp_up = client.put(f'/api/turmas/{turma_id}', json={'nome': 'TurmaX'}, headers=headers)
+    assert resp_up.status_code == 200
+    assert resp_up.get_json()['nome'] == 'TurmaX'
+
+    resp_get = client.get(f'/api/turmas/{turma_id}', headers=headers)
+    assert resp_get.status_code == 200
+    assert resp_get.get_json()['nome'] == 'TurmaX'
+
+
+def test_atualizar_turma_nome_duplicado(client):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+
+    r1 = client.post('/api/turmas', json={'nome': 'A'}, headers=headers)
+    r2 = client.post('/api/turmas', json={'nome': 'B'}, headers=headers)
+    turma_b = r2.get_json()['id']
+
+    resp = client.put(f'/api/turmas/{turma_b}', json={'nome': 'A'}, headers=headers)
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow missing JSON body in `turma` update
- register turma routes in tests
- add regression tests for turma API

## Testing
- `pytest tests/test_turma_routes.py -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6863373e359083239bbb428e965f0cb0