### PR TITLE
Fix instructor phone field

### DIFF
--- a/src/static/gerenciar-instrutores.html
+++ b/src/static/gerenciar-instrutores.html
@@ -220,6 +220,15 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="instrutorTelefone" class="form-label">Telefone</label>
+                                    <input type="tel" class="form-control" id="instrutorTelefone" placeholder="(XX) XXXXX-XXXX">
+                                </div>
+                            </div>
+                        </div>
                         
                         <div class="row">
                             <div class="col-md-6">

--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -372,6 +372,7 @@ class GerenciadorInstrutores {
             document.getElementById('instrutorId').value = instrutor.id;
             document.getElementById('instrutorNome').value = instrutor.nome;
             document.getElementById('instrutorEmail').value = instrutor.email || '';
+            document.getElementById('instrutorTelefone').value = instrutor.telefone || '';
             document.getElementById('instrutorAreaAtuacao').value = instrutor.area_atuacao || '';
             this.carregarCapacidadesSugeridas(instrutor.area_atuacao || '');
             document.getElementById('instrutorStatus').value = instrutor.status;
@@ -415,6 +416,7 @@ class GerenciadorInstrutores {
         const formData = {
             nome: document.getElementById('instrutorNome').value.trim(),
             email: document.getElementById('instrutorEmail').value.trim(),
+            telefone: document.getElementById('instrutorTelefone').value.trim(),
             area_atuacao: document.getElementById('instrutorAreaAtuacao').value,
             status: document.getElementById('instrutorStatus').value,
             observacoes: document.getElementById('instrutorObservacoes').value.trim(),


### PR DESCRIPTION
## Summary
- add phone input to instructor modal
- include `telefone` field when editing and saving instructors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_686453fb99ac8323adf66bb1c67918e6