### PR TITLE
Fix instructor listing endpoint

### DIFF
--- a/src/static/js/instrutores.js
+++ b/src/static/js/instrutores.js
@@ -68,7 +68,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         try {
             // Endpoint deve coincidir exatamente com o definido no backend
-            const instrutores = await chamarAPI('/api/instrutores', 'GET');
+            const instrutores = await chamarAPI('/instrutores', 'GET');
             renderizarTabela(instrutores);
         } catch (error) {
             // Se a chamarAPI falhar (incluindo erro 401), exibe uma mensagem de erro na tabela.


### PR DESCRIPTION
## Summary
- fix the instructors endpoint in the JS frontend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6864656c1c548323a6ea1aa7ff0331d2