### PR TITLE
Implementa novo modal de resumo e exclusão parcial

### DIFF
--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -428,11 +428,13 @@ def remover_ocupacao(id):
         return jsonify({'erro': 'Permissão negada'}), 403
     
     try:
+        somente_dia = request.args.get('somente_dia', default=False, type=lambda v: str(v).lower() == 'true')
         grupo_id = ocupacao.grupo_ocupacao_id
-        if grupo_id:
-            ocupacoes = Ocupacao.query.filter_by(grupo_ocupacao_id=grupo_id).all()
-        else:
+
+        if somente_dia or not grupo_id:
             ocupacoes = [ocupacao]
+        else:
+            ocupacoes = Ocupacao.query.filter_by(grupo_ocupacao_id=grupo_id).all()
 
         quantidade = len(ocupacoes)
         for oc in ocupacoes:

--- a/src/static/calendario-salas.html
+++ b/src/static/calendario-salas.html
@@ -253,8 +253,7 @@
                     <h5 class="modal-title" id="modalResumoDiaLabel">Resumo de Ocupação</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body" id="conteudoResumoDia">
-                </div>
+                <div class="modal-body" id="conteudoResumoDia"></div>
             </div>
         </div>
     </div>
@@ -268,15 +267,13 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <p>Tem certeza que deseja excluir este agendamento completo?</p>
-                    <div id="resumoOcupacaoExcluir"></div>
-                    <p class="text-muted small mt-3">Esta ação não pode ser desfeita.</p>
+                    <p>Você está prestes a excluir a ocupação do curso <strong id="resumoOcupacaoExcluir"></strong>. Esta ação não pode ser desfeita.</p>
+                    <p class="mt-2">Como deseja prosseguir?</p>
                 </div>
                 <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-danger" onclick="confirmarExclusaoOcupacao('dia')">Excluir Somente Este Dia</button>
+                    <button type="button" class="btn btn-danger" onclick="confirmarExclusaoOcupacao('total')">Excluir Todo o Período Agendado</button>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="button" class="btn btn-danger" onclick="confirmarExclusaoOcupacao()">
-                        <i class="bi bi-trash me-1"></i>Excluir
-                    </button>
                 </div>
             </div>
         </div>

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -440,6 +440,23 @@ small, .small {
   display: none;
 }
 
+/* Novo layout do resumo de ocupação */
+.resumo-turno {
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #dee2e6;
+}
+.resumo-turno:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+.resumo-turno h5 {
+  font-weight: 500;
+}
+.resumo-ocupada-item {
+  line-height: 1.2;
+}
+
 @media (max-width: 576px) {
   .resumo-card-header span.badge {
     font-size: 0.7rem;


### PR DESCRIPTION
## Resumo
- atualiza `remover_ocupacao` para aceitar exclusão de um único dia via query `somente_dia`
- refatora modal de resumo do dia em `calendario-salas.html`
- ajusta modal de confirmação de exclusão com opções parcial e total
- atualiza estilos para o novo layout do resumo
- reescreve funções JS de resumo e exclusão em `calendario-salas.js`

## Testes
- `pytest` *(falhou: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6865bb88e7b88323bd466b265c644b99