### PR TITLE
Fix resources array serialization when editing rooms

### DIFF
--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -204,11 +204,9 @@ class GerenciadorSalas {
 
     // Retorna lista de recursos marcados no formulario da sala
     coletarRecursosSelecionados() {
-        const recursos = [];
-        document
-            .querySelectorAll('#formSala input[name="recursos"]:checked')
-            .forEach(cb => recursos.push(cb.value));
-        return recursos;
+        return Array.from(
+            document.querySelectorAll('#formSala input[name="recursos"]:checked')
+        ).map(cb => cb.value);
     }
 
 // Edita uma sala existente


### PR DESCRIPTION
## Summary
- ensure selected room resources are serialized by value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6865d3ef7f688323955ae8a16247700d