### PR TITLE
Fix recurring occupancy update availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,5 @@
 - Sidebar do Gerenciamento de Usuários atualizada para exibir apenas "Lista de Usuários" e "Meu Perfil".
 - Removido carregamento automático do link "Laboratórios e Turmas" nesse módulo.
 - Formulário de nova sala simplificado com opções fixas de localização e menos campos.
+### Fixed
+- Edição de ocupações recorrentes agora ignora o próprio grupo ao verificar disponibilidade.

--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -375,8 +375,16 @@ def atualizar_ocupacao(id):
         
         # Verifica disponibilidade da sala (excluindo a ocupação atual)
         sala = db.session.get(Sala, ocupacao.sala_id)
-        if not sala.is_disponivel(data_ocupacao, horario_inicio, horario_fim, ocupacao.id):
-            conflitos = Ocupacao.buscar_conflitos(ocupacao.sala_id, data_ocupacao, horario_inicio, horario_fim, ocupacao.id)
+        grupo_id = ocupacao.grupo_ocupacao_id
+        if not sala.is_disponivel(data_ocupacao, horario_inicio, horario_fim, ocupacao.id, grupo_id):
+            conflitos = Ocupacao.buscar_conflitos(
+                ocupacao.sala_id,
+                data_ocupacao,
+                horario_inicio,
+                horario_fim,
+                ocupacao.id,
+                grupo_id
+            )
             return jsonify({
                 'erro': 'Sala não disponível no horário solicitado',
                 'conflitos': [c.to_dict(include_relations=False) for c in conflitos]


### PR DESCRIPTION
## Summary
- account for recurring groups when verifying availability during updates
- document bug fix in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6865d9e161f08323a6dd3b083c2c8254