### PR TITLE
Fix calendar update issues

### DIFF
--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -19,6 +19,13 @@ from sqlalchemy import and_, or_, func, extract
 
 ocupacao_bp = Blueprint('ocupacao', __name__)
 
+# Desabilita cache para todas as respostas deste blueprint para evitar que o
+# navegador utilize dados antigos ao atualizar ou excluir ocupações.
+@ocupacao_bp.after_request
+def add_no_cache_headers(response):
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
 TURNOS_PADRAO = {
     'Manhã': (time.fromisoformat('08:00'), time.fromisoformat('12:00')),
     'Tarde': (time.fromisoformat('13:30'), time.fromisoformat('17:30')),

--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -628,7 +628,9 @@ async function confirmarExclusaoOcupacao(modo) {
             const modal = bootstrap.Modal.getInstance(document.getElementById('modalExcluirOcupacao'));
             modal.hide();
 
-            // Atualiza o calendário e o resumo
+            // Remove evento imediatamente e atualiza dados
+            const ev = calendar.getEventById(ocupacaoId);
+            if (ev) ev.remove();
             calendar.refetchEvents();
             await carregarResumoPeriodo(
                 calendar.view.activeStart.toISOString().split('T')[0],


### PR DESCRIPTION
## Summary
- disable caching for ocupacao blueprint responses
- remove event from calendar immediately after deletion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6865dc94257c8323a7935e60d00b73dd