### PR TITLE
Skip weekend days when scheduling aulas regulares

### DIFF
--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -283,6 +283,10 @@ def criar_ocupacao():
         ocupacoes_criadas = []
         dia = data_inicio
         while dia <= data_fim:
+            # Se o tipo de ocupação for 'aula_regular' e o dia for sábado ou domingo, ignora
+            if payload.tipo_ocupacao == 'aula_regular' and dia.weekday() >= 5:
+                dia += timedelta(days=1)
+                continue
             nova_ocupacao = Ocupacao(
                 sala_id=payload.sala_id,
                 instrutor_id=payload.instrutor_id,
@@ -377,6 +381,10 @@ def atualizar_ocupacao(id):
         ocupacoes_criadas = []
         dia_atual = data_inicio
         while dia_atual <= data_fim:
+            # Se o tipo de ocupação for 'aula_regular' e o dia for sábado ou domingo, ignora
+            if payload.tipo_ocupacao == 'aula_regular' and dia_atual.weekday() >= 5:
+                dia_atual += timedelta(days=1)
+                continue
             nova_ocupacao = Ocupacao(
                 sala_id=sala_id,
                 instrutor_id=instrutor_id,

--- a/src/static/js/nova-ocupacao.js
+++ b/src/static/js/nova-ocupacao.js
@@ -388,6 +388,30 @@ function exibirAlerta(mensagem, tipo) {
     }, 5000);
 }
 
+// Exibe aviso quando "Aula Regular" é selecionada
+function monitorarSelecaoAulaRegular() {
+    const tipoOcupacaoSelect = document.getElementById('tipoOcupacao');
+    const dataInicioInput = document.getElementById('dataInicio');
+    const dataFimInput = document.getElementById('dataFim');
+
+    const avisoDiv = document.createElement('div');
+    avisoDiv.className = 'form-text text-muted mt-2';
+    avisoDiv.id = 'aviso-fim-de-semana';
+    dataFimInput.parentNode.appendChild(avisoDiv);
+
+    const verificarAviso = () => {
+        if (tipoOcupacaoSelect.value === 'aula_regular') {
+            avisoDiv.innerHTML = '<i class="bi bi-info-circle"></i> Lembrete: Sábados e domingos serão ignorados para agendamentos de Aulas Regulares.';
+            avisoDiv.style.display = 'block';
+        } else {
+            avisoDiv.style.display = 'none';
+        }
+    };
+
+    tipoOcupacaoSelect.addEventListener('change', verificarAviso);
+    verificarAviso();
+}
+
 // Garante envio correto do formulário em modo de edição ou criação
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('formNovaOcupacao');
@@ -397,5 +421,8 @@ document.addEventListener('DOMContentLoaded', () => {
             await salvarOcupacao();
         });
     }
+
+    // Inicia monitoramento para avisos de "Aula Regular"
+    monitorarSelecaoAulaRegular();
 });
 


### PR DESCRIPTION
## Summary
- ignore weekends when generating aula_regular bookings
- apply same rule when updating recurring bookings
- show informational message on form about weekend skipping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68667834a680832397c0aed6e17f427a