### PR TITLE
Implement calendar summary pills

### DIFF
--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -240,6 +240,22 @@
         </div>
     </div>
 
+    <!-- Modal Resumo de Agendamentos -->
+    <div class="modal fade" id="modalResumoAgendamentos" tabindex="-1" aria-labelledby="modalResumoAgendamentosLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="modalResumoAgendamentosLabel">Resumo de Agendamentos</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <div class="modal-body" id="conteudoResumoAgendamentos"></div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Modal de Confirmação de Exclusão -->
     <div class="modal fade" id="confirmacaoModal" tabindex="-1" aria-labelledby="confirmacaoModalLabel" aria-hidden="true">
         <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- add backend route to aggregate lab occupation by day/shift
- show pill-style occupancy in lab calendar
- create modal with daily summary details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68667bd58a788323b9fcf34522fbd02e