### PR TITLE
Fix calendar update after deleting schedules

### DIFF
--- a/src/static/js/calendario-labs.js
+++ b/src/static/js/calendario-labs.js
@@ -2,6 +2,7 @@
 let calendar;
 let resumoDias = {};
 let totalLaboratorios = 0;
+let diaResumoAtual = null;
 
 function inicializarCalendario() {
     const calendarEl = document.getElementById('calendario');
@@ -91,6 +92,7 @@ async function carregarResumoCalendario(inicio, fim) {
 }
 
 async function mostrarResumoAgendamentos(dataStr) {
+    diaResumoAtual = dataStr;
     const modalEl = document.getElementById('modalResumoAgendamentos');
     const modal = new bootstrap.Modal(modalEl);
     const container = document.getElementById('conteudoResumoAgendamentos');
@@ -174,6 +176,14 @@ function excluirAgendamento(id) {
             confirmModal.hide();
             exibirAlerta('Agendamento excluído com sucesso!', 'success');
             calendar.refetchEvents();
+            await carregarResumoCalendario(
+                calendar.view.activeStart.toISOString(),
+                calendar.view.activeEnd.toISOString()
+            );
+            renderizarPillulas(resumoDias, totalLaboratorios);
+            if (diaResumoAtual) {
+                mostrarResumoAgendamentos(diaResumoAtual);
+            }
         } catch (error) {
             exibirAlerta(`Erro ao excluir agendamento: ${error.message}`, 'danger');
         }


### PR DESCRIPTION
## Summary
- update calendar script to track selected day
- refresh calendar summary when deleting a schedule

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68669d3d78ac8323959cf87aac22c80f