### PR TITLE
Refactor calendar for labs

### DIFF
--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -125,44 +125,9 @@
             <!-- Conteúdo principal -->
             <div class="col-lg-9">
                 <h2 class="mb-4">Calendário de Agendamentos</h2>
-                
+
                 <div id="alertContainer"></div>
-                
-                <!-- Filtros em telas menores -->
-                <div class="d-lg-none mb-4">
-                    <div class="card">
-                        <div class="card-header">
-                            <h5 class="card-title mb-0">Filtros</h5>
-                        </div>
-                        <div class="card-body">
-                            <form id="filtrosMobileForm" class="row g-3">
-                                <div class="col-md-6">
-                                    <label for="filtroLaboratorioMobile" class="form-label">Laboratório</label>
-                                    <select class="form-select" id="filtroLaboratorioMobile">
-                                        <option value="">Todos</option>
-                                        <!-- Opções serão carregadas dinamicamente -->
-                                    </select>
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="filtroTurnoMobile" class="form-label">Turno</label>
-                                    <select class="form-select" id="filtroTurnoMobile">
-                                        <option value="">Todos</option>
-                                        <option value="Manhã">Manhã</option>
-                                        <option value="Tarde">Tarde</option>
-                                        <option value="Noite">Noite</option>
-                                    </select>
-                                </div>
-                                <div class="col-12">
-                                    <button type="submit" class="btn btn-primary w-100">
-                                        <i class="bi bi-funnel me-2"></i>Filtrar
-                                    </button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Legenda de Status -->
+
                 <div class="card mb-3">
                     <div class="card-body">
                         <h6 class="card-subtitle mb-2 text-muted">Legenda</h6>
@@ -182,8 +147,7 @@
                         </div>
                     </div>
                 </div>
-                
-                <!-- Calendário -->
+
                 <div class="card">
                     <div class="card-body">
                         <div id="loadingCalendario" class="text-center py-4">
@@ -192,11 +156,10 @@
                             </div>
                             <p class="mt-2">Carregando agendamentos...</p>
                         </div>
-
                         <div id="calendario" style="display: none;"></div>
                     </div>
                 </div>
-                
+
                 <div class="d-flex justify-content-end mt-4">
                     <a href="/novo-agendamento.html" class="btn btn-primary">
                         <i class="bi bi-plus-circle me-2"></i>Novo Agendamento

--- a/src/static/js/calendario-labs.js
+++ b/src/static/js/calendario-labs.js
@@ -1,8 +1,19 @@
-// Calendário de agendamentos com resumo por turno
+// CÓDIGO COMPLETO E ADAPTADO PARA calendario-labs.js
+
+document.addEventListener('DOMContentLoaded', function() {
+    if (!verificarAutenticacao()) return;
+
+    // Atualiza nome do usuário na navbar
+    const usuario = getUsuarioLogado();
+    if(usuario) document.getElementById('userName').textContent = usuario.nome;
+
+    // Carrega filtros e inicializa o calendário
+    carregarLaboratoriosParaFiltro();
+    configurarFiltros();
+    inicializarCalendario();
+});
+
 let calendar;
-let resumoDias = {};
-let totalLaboratorios = 0;
-let diaResumoAtual = null;
 
 function inicializarCalendario() {
     const calendarEl = document.getElementById('calendario');
@@ -22,7 +33,6 @@ function inicializarCalendario() {
         },
         height: 'auto',
 
-        // 1. Injeta um container nas células do calendário para receber as pílulas.
         dayCellContent: function(arg) {
             const dateStr = arg.date.toISOString().slice(0, 10);
             return {
@@ -31,44 +41,8 @@ function inicializarCalendario() {
             };
         },
 
-        // 2. A propriedade 'events' não será usada para buscar dados, apenas para eventos pontuais se necessário.
-        events: function(fetchInfo, successCallback, failureCallback) {
-            // Devolvemos um array vazio porque a nossa renderização é customizada.
-            successCallback([]);
-        },
-
-        // 3. USA-SE O 'datesSet' PARA BUSCAR DADOS E RENDERIZAR AS PÍLULAS.
-        // Este evento é acionado sempre que a faixa de datas do calendário muda.
         datesSet: async function(dateInfo) {
-            try {
-                const params = new URLSearchParams({
-                    data_inicio: dateInfo.startStr.slice(0, 10),
-                    data_fim: dateInfo.endStr.slice(0, 10)
-                });
-
-                const response = await fetch(`${API_URL}/agendamentos/resumo-calendario?${params.toString()}`, {
-                    headers: { 'Authorization': `Bearer ${getToken()}` }
-                });
-
-                if (!response.ok) {
-                    throw new Error('Falha ao carregar resumo do calendário');
-                }
-
-                const data = await response.json();
-                renderizarPillulas(data.resumo, data.total_laboratorios);
-
-            } catch (error) {
-                console.error("Erro ao buscar ou renderizar resumo de agendamentos:", error);
-                // Opcional: exibir um alerta de erro para o usuário.
-            }
-        },
-        
-        // 4. A função de clique no dia abre o modal de resumo, como antes.
-        dateClick: function(info) {
-             // Esta função deve chamar o seu modal de resumo.
-             // Se o modal já funciona, esta parte está correta.
-             // Exemplo: mostrarResumoAgendamentos(info.dateStr);
-             mostrarResumoAgendamentos(info.dateStr);
+            aplicarFiltrosCalendario();
         }
     });
     
@@ -77,169 +51,71 @@ function inicializarCalendario() {
     document.getElementById('calendario').style.display = 'block';
 }
 
-async function carregarResumoCalendario(inicio, fim) {
-    const params = new URLSearchParams({
-        data_inicio: inicio.split('T')[0],
-        data_fim: fim.split('T')[0]
-    });
-    const resp = await fetch(`${API_URL}/agendamentos/resumo-calendario?${params.toString()}`, {
-        headers: { 'Authorization': `Bearer ${getToken()}` }
-    });
-    if (!resp.ok) throw new Error('Erro ao obter resumo');
-    const dados = await resp.json();
-    resumoDias = dados.resumo || {};
-    totalLaboratorios = dados.total_laboratorios || 0;
-}
-
-async function mostrarResumoAgendamentos(dataStr) {
-    diaResumoAtual = dataStr;
-    const modalEl = document.getElementById('modalResumoAgendamentos');
-    const modal = new bootstrap.Modal(modalEl);
-    const container = document.getElementById('conteudoResumoAgendamentos');
-    document.getElementById('modalResumoAgendamentosLabel').textContent = 'Resumo de Agendamentos – ' + formatarData(dataStr);
-    container.innerHTML = '<div class="text-center py-3"><div class="spinner-border text-primary" role="status"></div></div>';
+async function carregarLaboratoriosParaFiltro() {
     try {
-        const [agendamentos, laboratorios] = await Promise.all([
-            chamarAPI(`/agendamentos/calendario?data_inicio=${dataStr}&data_fim=${dataStr}`),
-            chamarAPI('/laboratorios')
-        ]);
-        const nomesLabs = laboratorios.map(l => l.nome);
-        container.innerHTML = '';
-        ['Manhã', 'Tarde', 'Noite'].forEach(turno => {
-            const eventos = agendamentos.filter(e => e.extendedProps.turno === turno);
-            const ocupados = eventos.map(e => e.extendedProps.laboratorio);
-            const livres = nomesLabs.filter(n => !ocupados.includes(n));
-            const card = document.createElement('div');
-            card.className = 'card mb-3';
-            const header = document.createElement('div');
-            header.className = 'card-header bg-light d-flex justify-content-between align-items-center';
-            header.innerHTML = `<h6 class="mb-0">${escapeHTML(turno)}</h6><span class="badge bg-secondary">${eventos.length} / ${nomesLabs.length} Laboratórios</span>`;
-            card.appendChild(header);
-            const body = document.createElement('div');
-            body.className = 'card-body';
-            let html = '<div class="row">';
-            html += '<div class="col-md-7">';
-            html += '<h6><i class="bi bi-flask text-danger"></i> Laboratórios Ocupados:</h6>';
-            if (eventos.length) {
-                html += '<ul class="list-group list-group-flush">';
-                eventos.forEach(ev => {
-                    const p = ev.extendedProps;
-                    html += `<li class="list-group-item d-flex justify-content-between align-items-center">` +
-                             `<div><strong>${escapeHTML(p.laboratorio)}:</strong> ${escapeHTML(p.turma)}</div>` +
-                             `<div class="btn-group">` +
-                             `<button class="btn btn-sm btn-outline-primary btn-editar-agendamento" data-id="${ev.id}" title="Editar"><i class="bi bi-pencil"></i></button>` +
-                             `<button class="btn btn-sm btn-outline-danger btn-excluir-agendamento" data-id="${ev.id}" title="Excluir"><i class="bi bi-trash"></i></button>` +
-                             `</div></li>`;
-                });
-                html += '</ul>';
-            } else {
-                html += '<p class="fst-italic text-muted">Nenhum laboratório ocupado neste turno.</p>';
-            }
-            html += '</div>';
-            html += '<div class="col-md-5">';
-            html += '<h6><i class="bi bi-flask-fill text-success"></i> Laboratórios Livres:</h6>';
-            if (livres.length) {
-                livres.forEach(n => {
-                    html += `<span class="badge bg-light text-dark border me-1 mb-1">${escapeHTML(n)}</span>`;
-                });
-            } else {
-                html += '<p class="fst-italic text-muted">Todos os laboratórios estão ocupados.</p>';
-            }
-            html += '</div></div>';
-            body.innerHTML = sanitizeHTML(html);
-            card.appendChild(body);
-            container.appendChild(card);
+        const laboratorios = await chamarAPI('/laboratorios');
+        const select = document.getElementById('filtroLaboratorio');
+        select.innerHTML = '<option value="">Todos</option>';
+        laboratorios.forEach(lab => {
+            select.innerHTML += `<option value="${lab.nome}">${lab.nome}</option>`;
         });
-        container.querySelectorAll('.btn-editar-agendamento').forEach(btn => {
-            btn.addEventListener('click', e => editarAgendamento(e.currentTarget.getAttribute('data-id')));
-        });
-        container.querySelectorAll('.btn-excluir-agendamento').forEach(btn => {
-            btn.addEventListener('click', e => excluirAgendamento(e.currentTarget.getAttribute('data-id')));
-        });
-    } catch (err) {
-        console.error('Erro ao carregar resumo', err);
-        container.innerHTML = '<p class="text-danger">Erro ao carregar dados.</p>';
-    }
-    modal.show();
-}
-
-function editarAgendamento(id) {
-    window.location.href = `/novo-agendamento.html?id=${id}`;
-}
-
-function excluirAgendamento(id) {
-    const confirmModal = new bootstrap.Modal(document.getElementById('confirmacaoModal'));
-    confirmModal.show();
-    document.getElementById('btnConfirmarExclusao').onclick = async () => {
-        try {
-            await chamarAPI(`/agendamentos/${id}`, 'DELETE');
-            confirmModal.hide();
-            exibirAlerta('Agendamento excluído com sucesso!', 'success');
-            calendar.refetchEvents();
-            await carregarResumoCalendario(
-                calendar.view.activeStart.toISOString(),
-                calendar.view.activeEnd.toISOString()
-            );
-            renderizarPillulas(resumoDias, totalLaboratorios);
-            if (diaResumoAtual) {
-                mostrarResumoAgendamentos(diaResumoAtual);
-            }
-        } catch (error) {
-            exibirAlerta(`Erro ao excluir agendamento: ${error.message}`, 'danger');
-        }
-    };
-}
-
-function aplicarFiltrosCalendario() {
-    if (calendar) {
-        calendar.refetchEvents();
+    } catch (error) {
+        console.error('Erro ao carregar laboratórios:', error);
     }
 }
 
 function configurarFiltros() {
-    const form = document.getElementById('filtrosForm');
-    const formMobile = document.getElementById('filtrosMobileForm');
-    if (form) {
-        form.addEventListener('submit', e => {
-            e.preventDefault();
-            document.getElementById('filtroLaboratorioMobile').value = document.getElementById('filtroLaboratorio').value;
-            document.getElementById('filtroTurnoMobile').value = document.getElementById('filtroTurno').value;
-            aplicarFiltrosCalendario();
+    document.getElementById('filtrosForm').addEventListener('submit', function(e) {
+        e.preventDefault();
+        aplicarFiltrosCalendario();
+    });
+}
+
+async function aplicarFiltrosCalendario() {
+    if (!calendar) return;
+
+    try {
+        const params = new URLSearchParams({
+            data_inicio: calendar.view.activeStart.toISOString().slice(0, 10),
+            data_fim: calendar.view.activeEnd.toISOString().slice(0, 10),
         });
-    }
-    if (formMobile) {
-        formMobile.addEventListener('submit', e => {
-            e.preventDefault();
-            document.getElementById('filtroLaboratorio').value = document.getElementById('filtroLaboratorioMobile').value;
-            document.getElementById('filtroTurno').value = document.getElementById('filtroTurnoMobile').value;
-            aplicarFiltrosCalendario();
+
+        // Adiciona filtros selecionados aos parâmetros
+        const laboratorio = document.getElementById('filtroLaboratorio').value;
+        const turno = document.getElementById('filtroTurno').value;
+        if (laboratorio) params.append('laboratorio', laboratorio);
+        if (turno) params.append('turno', turno);
+
+        const response = await fetch(`${API_URL}/agendamentos/resumo-calendario?${params.toString()}`, {
+            headers: { 'Authorization': `Bearer ${getToken()}` }
         });
+
+        if (!response.ok) throw new Error('Falha ao carregar resumo do calendário');
+
+        const data = await response.json();
+        renderizarPillulas(data.resumo, data.total_recursos);
+        
+    } catch (error) {
+        console.error("Erro ao buscar ou renderizar resumo de agendamentos:", error);
     }
 }
 
-// Esta função auxiliar desenha as pílulas e deve estar no mesmo ficheiro.
-function renderizarPillulas(resumo, totalLabs) {
-    if (!resumo || totalLabs === 0) {
-        // Limpa o calendário se não houver dados
-        document.querySelectorAll('.day-pills-container').forEach(c => c.innerHTML = '');
-        return;
-    };
-
+function renderizarPillulas(resumo, totalRecursos) {
     document.querySelectorAll('.day-pills-container').forEach(container => {
         const dataStr = container.getAttribute('data-date');
-        const diaResumo = resumo[dataStr];
+        const diaResumo = resumo ? resumo[dataStr] : null;
         let html = '';
 
-        ['Manhã', 'Tarde', 'Noite'].forEach(turno => {
-            const ocupados = diaResumo && diaResumo[turno] ? diaResumo[turno].ocupados : 0;
-
-            let statusClass = 'turno-livre'; // Padrão é livre
-            if (ocupados > 0) {
-                statusClass = ocupados >= totalLabs ? 'turno-cheio' : 'turno-parcial';
-            }
-
-            html += `<div class="pill-turno ${statusClass}">${turno}: ${ocupados}/${totalLabs}</div>`;
-        });
+        if (totalRecursos > 0) {
+            ['Manhã', 'Tarde', 'Noite'].forEach(turno => {
+                const ocupados = diaResumo && diaResumo[turno] ? diaResumo[turno].ocupados : 0;
+                let statusClass = 'turno-livre';
+                if (ocupados > 0) {
+                    statusClass = ocupados >= totalRecursos ? 'turno-cheio' : 'turno-parcial';
+                }
+                html += `<div class="pill-turno ${statusClass}">${turno}: ${ocupados}/${totalRecursos}</div>`;
+            });
+        }
         container.innerHTML = html;
     });
 }


### PR DESCRIPTION
## Summary
- update `/agendamentos/resumo-calendario` backend route for labs
- simplify labs calendar page HTML
- rebuild JS for labs calendar based on occupation calendar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6866bd07fef48323ab4a215006c40024