### PR TITLE
Unify agendamento calendar with ocupacao layout

### DIFF
--- a/src/static/calendario-agendamentos-v2.html
+++ b/src/static/calendario-agendamentos-v2.html
@@ -64,19 +64,25 @@
                 <div class="sidebar rounded shadow-sm">
                     <h5 class="mb-3">Menu Principal</h5>
                     <div class="nav flex-column">
-                        <a class="nav-link" href="/index.html">
+                        <a class="nav-link" href="/dashboard-salas.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
-                        <a class="nav-link active" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link active" href="/calendario-salas.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
-                        <a class="nav-link" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle"></i> Novo Agendamento
+                        <a class="nav-link" href="/gerenciar-salas.html">
+                            <i class="bi bi-building"></i> Gerenciar Salas
                         </a>
-                        <a class="nav-link admin-only" href="/laboratorios-turmas.html">
-                            <i class="bi bi-building"></i> Laboratórios e Turmas
+                        <a class="nav-link" href="/corpo-docente.html">
+                            <i class="bi bi-person-badge"></i> Corpo Docente
                         </a>
-                        <a class="nav-link" href="/perfil.html">
+                        <a class="nav-link" href="/gerenciar-turmas.html">
+                            <i class="bi bi-building"></i> Gerenciar Turmas
+                        </a>
+                        <a class="nav-link" href="/novo-agendamento-sala.html">
+                            <i class="bi bi-plus-circle"></i> Nova Ocupação
+                        </a>
+                        <a class="nav-link" href="/perfil-salas.html">
                             <i class="bi bi-person"></i> Meu Perfil
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
- align `calendario-agendamentos-v2.html` layout with the occupancy calendar
- update button and filters to use `Laboratório`
- replace `calendario-labs.js` with code adapted from the occupancy calendar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68670bc2bf408323b7ac0a941c86aba1