### PR TITLE
Atualiza página e script de calendário de agendamentos

### DIFF
--- a/src/static/calendario-agendamentos-v2.html
+++ b/src/static/calendario-agendamentos-v2.html
@@ -27,18 +27,22 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/index.html">
                             <i class="bi bi-speedometer2 me-1"></i> Dashboard
+                        </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link active" href="/calendario-agendamentos-v2.html">
                             <i class="bi bi-calendar3 me-1"></i> Calendário
+                        </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="/novo-agendamento.html">
                             <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
+                        </a>
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/laboratorios-turmas.html">
                             <i class="bi bi-building me-1"></i> Laboratórios e Turmas
+                        </a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -46,6 +50,7 @@
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="bi bi-person-circle me-1"></i>
                             <span id="userName">Usuário</span>
+                        </a>
                         <ul class="dropdown-menu">
                             <li><a class="dropdown-item" href="/perfil.html"><i class="bi bi-person me-2"></i>Meu Perfil</a></li>
                             <li><hr class="dropdown-divider"></li>
@@ -64,25 +69,19 @@
                 <div class="sidebar rounded shadow-sm">
                     <h5 class="mb-3">Menu Principal</h5>
                     <div class="nav flex-column">
-                        <a class="nav-link" href="/dashboard-salas.html">
+                        <a class="nav-link" href="/index.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
-                        <a class="nav-link active" href="/calendario-salas.html">
+                        <a class="nav-link active" href="/calendario-agendamentos-v2.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
-                        <a class="nav-link" href="/gerenciar-salas.html">
-                            <i class="bi bi-building"></i> Gerenciar Salas
+                        <a class="nav-link" href="/novo-agendamento.html">
+                            <i class="bi bi-plus-circle"></i> Novo Agendamento
                         </a>
-                        <a class="nav-link" href="/corpo-docente.html">
-                            <i class="bi bi-person-badge"></i> Corpo Docente
+                        <a class="nav-link admin-only" href="/laboratorios-turmas.html">
+                            <i class="bi bi-building"></i> Laboratórios e Turmas
                         </a>
-                        <a class="nav-link" href="/gerenciar-turmas.html">
-                            <i class="bi bi-building"></i> Gerenciar Turmas
-                        </a>
-                        <a class="nav-link" href="/novo-agendamento-sala.html">
-                            <i class="bi bi-plus-circle"></i> Nova Ocupação
-                        </a>
-                        <a class="nav-link" href="/perfil-salas.html">
+                        <a class="nav-link" href="/perfil.html">
                             <i class="bi bi-person"></i> Meu Perfil
                         </a>
                     </div>
@@ -154,23 +153,24 @@
 
                 <!-- Legenda de Ocupação -->
                 <div class="card mb-3">
-    <div class="card-body py-2">
-        <div class="legenda-cores">
-            <div class="legenda-item">
-                <div class="legenda-cor-status turno-livre"></div>
-                <span>Livre</span>
-            </div>
-            <div class="legenda-item">
-                <div class="legenda-cor-status turno-parcial"></div>
-                <span>Parcial</span>
-            </div>
-            <div class="legenda-item">
-                <div class="legenda-cor-status turno-cheio"></div>
-                <span>Cheio</span>
-            </div>
-        </div>
-    </div>
-</div>
+                    <div class="card-body">
+                        <h6 class="card-subtitle mb-2 text-muted">Legenda</h6>
+                        <div class="legenda-turnos">
+                            <div class="legenda-item">
+                                <div class="pill-turno turno-livre"></div>
+                                <span>Livre</span>
+                            </div>
+                            <div class="legenda-item">
+                                <div class="pill-turno turno-parcial"></div>
+                                <span>Parcial</span>
+                            </div>
+                            <div class="legenda-item">
+                                <div class="pill-turno turno-cheio"></div>
+                                <span>Cheio</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <!-- Calendário -->
                 <div class="card">
                     <div class="card-body">
@@ -178,7 +178,7 @@
                             <div class="spinner-border text-primary" role="status">
                                 <span class="visually-hidden">Carregando...</span>
                             </div>
-                            <p class="mt-2">Carregando agendamentos...</p>
+                            <p class="mt-2">Carregando ocupações...</p>
                         </div>
 
                         <div id="calendario" style="display: none;"></div>
@@ -194,22 +194,22 @@
         </div>
     </div>
 
-    <!-- Modal de Detalhes da Ocupação -->
-    <div class="modal fade" id="modalDetalhesOcupacao" tabindex="-1" aria-labelledby="modalDetalhesOcupacaoLabel" aria-hidden="true">
+    <!-- Modal de Detalhes do Agendamento -->
+    <div class="modal fade" id="modalDetalhesAgendamento" tabindex="-1" aria-labelledby="modalDetalhesAgendamentoLabel" aria-hidden="true">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalDetalhesOcupacaoLabel">Detalhes da Ocupação</h5>
+                    <h5 class="modal-title" id="modalDetalhesAgendamentoLabel">Detalhes do Agendamento</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <div id="detalhesOcupacaoContent">
+                    <div id="detalhesAgendamentoContent">
                         <!-- Conteúdo será preenchido via JavaScript -->
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
-                    <div id="acoesOcupacao">
+                    <div id="acoesAgendamento">
                         <!-- Botões de ação serão adicionados via JavaScript -->
                     </div>
                 </div>
@@ -222,7 +222,7 @@
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalResumoDiaLabel">Resumo de Ocupação</h5>
+                    <h5 class="modal-title" id="modalResumoDiaLabel">Resumo de Agendamentos</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body" id="conteudoResumoDia"></div>
@@ -231,15 +231,15 @@
     </div>
 
     <!-- Modal de Confirmação de Exclusão -->
-    <div class="modal fade" id="modalExcluirOcupacao" tabindex="-1" aria-labelledby="modalExcluirOcupacaoLabel" aria-hidden="true">
+    <div class="modal fade" id="modalExcluirAgendamento" tabindex="-1" aria-labelledby="modalExcluirAgendamentoLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalExcluirOcupacaoLabel">Confirmar Exclusão</h5>
+                    <h5 class="modal-title" id="modalExcluirAgendamentoLabel">Confirmar Exclusão</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <p>Você está prestes a excluir a ocupação do curso <strong id="resumoOcupacaoExcluir"></strong>. Esta ação não pode ser desfeita.</p>
+                    <p>Você está prestes a excluir o agendamento do curso <strong id="resumoAgendamentoExcluir"></strong>. Esta ação não pode ser desfeita.</p>
                     <p class="mt-2">Como deseja prosseguir?</p>
                 </div>
                 <div class="modal-footer">
@@ -258,7 +258,7 @@
     <script src="/js/app.js"></script>
     <script src="/js/calendario-labs.js"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener("DOMContentLoaded", function() {
             verificarAutenticacao();
             carregarLaboratoriosParaFiltro("#filtroLaboratorio");
             carregarLaboratoriosParaFiltro("#filtroLaboratorioMobile");

--- a/src/static/js/calendario-labs.js
+++ b/src/static/js/calendario-labs.js
@@ -1,145 +1,653 @@
-// CÓDIGO COMPLETO E ADAPTADO PARA O FICHEIRO calendario-labs.js
+// Funções para o calendário de ocupações de salas
 
-document.addEventListener('DOMContentLoaded', function() {
-    // Garante que o usuário está autenticado
-    if (!estaAutenticado()) {
-        window.location.href = '/admin-login.html';
-        return;
-    }
-    
-    // Atualiza o nome do usuário na navbar
-    const usuario = getUsuarioLogado();
-    if(usuario) {
-        const userNameElement = document.getElementById('userName') || document.getElementById('nomeUsuarioNav');
-        if(userNameElement) userNameElement.textContent = usuario.nome;
-    }
-    
-    // Carrega os dados para os filtros e depois inicializa o calendário
-    carregarLaboratoriosParaFiltro();
-    configurarFiltros();
-    inicializarCalendario();
-});
+// Variáveis globais
+let calendar;
+let ocupacoesData = [];
+let salasData = [];
+let instrutoresData = [];
+let tiposOcupacao = [];
+let resumoOcupacoes = {};
+let diaResumoAtual = null;
 
-let calendar; // Variável global para o calendário
+// Converte o nome do turno em um identificador CSS sem acentos
+function slugifyTurno(turno) {
+    return turno
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '');
+}
 
+// Inicializa o calendário
 function inicializarCalendario() {
     const calendarEl = document.getElementById('calendario');
-    if (!calendarEl) {
-        console.error("Elemento do calendário não encontrado!");
-        return;
-    }
+    
     calendar = new FullCalendar.Calendar(calendarEl, {
         initialView: 'dayGridMonth',
         locale: 'pt-br',
         headerToolbar: {
             left: 'prev,next today',
             center: 'title',
-            right: 'dayGridMonth,timeGridWeek,day'
+            right: 'dayGridMonth,timeGridWeek,timeGridDay'
         },
-        buttonText: { today: 'Hoje', month: 'Mês', week: 'Semana', day: 'Dia' },
+        buttonText: {
+            today: 'Hoje',
+            month: 'Mês',
+            week: 'Semana',
+            day: 'Dia'
+        },
         height: 'auto',
-
-        dayCellContent: function(arg) {
-            const dateStr = arg.date.toISOString().slice(0, 10);
-            return {
-                html: `<div class="fc-daygrid-day-number">${arg.dayNumberText}</div>
-                       <div class="day-pills-container" data-date="${dateStr}"></div>`
-            };
+        eventDisplay: 'block',
+        dayMaxEvents: 3,
+        moreLinkText: function(num) {
+            return `+${num} mais`;
         },
-
-        // Evento que dispara sempre que a visualização do calendário é alterada
-        datesSet: function(dateInfo) {
-            aplicarFiltrosCalendario();
+        eventClick: function(info) {
+            mostrarDetalhesAgendamento(info.event.extendedProps);
         },
-        
-        // Adicionar evento de clique para abrir o modal de resumo
         dateClick: function(info) {
-             // A função que abre o modal será implementada aqui ou chamada
-             console.log("Clicou no dia: ", info.dateStr);
-             // Ex: mostrarResumoAgendamentos(info.dateStr);
+            mostrarResumoAgendamentos(info.dateStr);
+        },
+        datesSet: function(info) {
+            carregarResumoPeriodo(info.startStr, info.endStr);
+        },
+        events: function(fetchInfo, successCallback, failureCallback) {
+            carregarOcupacoes(fetchInfo.startStr, fetchInfo.endStr)
+                .then(eventos => successCallback(eventos))
+                .catch(error => {
+                    console.error('Erro ao carregar eventos:', error);
+                    failureCallback(error);
+                });
         }
     });
     
     calendar.render();
+    
+    // Esconde loading e mostra calendário
     document.getElementById('loadingCalendario').style.display = 'none';
     document.getElementById('calendario').style.display = 'block';
 }
 
-async function carregarLaboratoriosParaFiltro() {
+// Carrega ocupações do servidor
+async function carregarOcupacoes(dataInicio, dataFim) {
     try {
-        const laboratorios = await chamarAPI('/laboratorios');
-        const select = document.getElementById('filtroLaboratorio');
-        if (!select) return;
-        select.innerHTML = '<option value="">Todos os laboratórios</option>';
-        laboratorios.forEach(lab => {
-            select.innerHTML += `<option value="${lab.nome}">${lab.nome}</option>`;
+        // Constrói parâmetros de filtro
+        const params = new URLSearchParams({
+            data_inicio: dataInicio.split('T')[0],
+            data_fim: dataFim.split('T')[0]
         });
+        
+        // Aplica filtros ativos
+        const laboratorio = document.getElementById('filtroLaboratorio').value;
+        const turno = document.getElementById('filtroTurno').value;
+        
+        if (laboratorio) params.append('laboratorio', laboratorio);
+        if (turno) params.append('turno', turno);
+        
+        const response = await fetch(`${API_URL}/ocupacoes/calendario?${params.toString()}`, {
+            headers: {
+                'Authorization': `Bearer ${getToken()}`
+            }
+        });
+        
+        if (response.ok) {
+            const eventos = await response.json();
+            ocupacoesData = eventos;
+            return eventos.map(evento => ({
+                id: evento.id,
+                title: evento.title,
+                start: evento.start,
+                end: evento.end,
+                className: getClasseTurno(evento.extendedProps.turno),
+                extendedProps: evento.extendedProps
+            }));
+        } else {
+            throw new Error('Erro ao carregar ocupações');
+        }
     } catch (error) {
-        console.error('Erro ao carregar laboratórios:', error);
+        console.error('Erro ao carregar ocupações:', error);
+        return [];
     }
 }
 
+// Carrega resumo de ocupações por período
+async function carregarResumoPeriodo(dataInicio, dataFim) {
+    try {
+        const params = new URLSearchParams({
+            data_inicio: dataInicio.split('T')[0],
+            data_fim: dataFim.split('T')[0]
+        });
+
+        const laboratorio = document.getElementById('filtroLaboratorio').value;
+        const turno = document.getElementById('filtroTurno').value;
+
+        if (laboratorio) params.append('laboratorio', laboratorio);
+        if (turno) params.append('turno', turno);
+
+        const response = await fetch(`${API_URL}/agendamentos/resumo-calendario?${params.toString()}`, {
+            headers: {
+                'Authorization': `Bearer ${getToken()}`
+            }
+        });
+
+        if (response.ok) {
+            resumoOcupacoes = await response.json();
+            atualizarResumoNoCalendario();
+        }
+    } catch (error) {
+        console.error('Erro ao carregar resumo:', error);
+    }
+}
+
+function atualizarResumoNoCalendario() {
+    document.querySelectorAll('.fc-daygrid-day').forEach(cell => {
+        const dateStr = cell.getAttribute('data-date');
+        cell.querySelectorAll('.pill-turno').forEach(e => e.remove());
+
+        const resumoDia = resumoOcupacoes[dateStr];
+        if (resumoDia) {
+            const popoverParts = [];
+            ['Manhã', 'Tarde', 'Noite'].forEach(turno => {
+                const info = resumoDia[turno];
+                if (!info) return;
+
+                const div = document.createElement('div');
+                div.classList.add('pill-turno');
+
+                if (info.ocupadas === 0) {
+                    div.classList.add('turno-livre');
+                } else if (info.ocupadas === info.total_salas) {
+                    div.classList.add('turno-cheio');
+                } else {
+                    div.classList.add('turno-parcial');
+                }
+
+                div.textContent = `${turno}: ${info.ocupadas}/${info.total_salas}`;
+                cell.appendChild(div);
+
+                const ocupadasNomes = info.salas_ocupadas.map(s => s.sala_nome).join(', ') || 'Nenhuma';
+                const livresNomes = info.salas_livres.join(', ') || 'Nenhuma';
+                popoverParts.push(
+                    `<div><strong>${escapeHTML(turno)}</strong><br>` +
+                    `Laboratórios Ocupados: ${escapeHTML(ocupadasNomes)}<br>` +
+                    `Laboratórios Livres: ${escapeHTML(livresNomes)}</div>`
+                );
+            });
+
+            const popoverContent = popoverParts.join('<hr>');
+            const existing = bootstrap.Popover.getInstance(cell);
+            if (existing) existing.dispose();
+            new bootstrap.Popover(cell, {
+                html: true,
+                trigger: 'hover focus',
+                container: 'body',
+                content: sanitizeHTML(popoverContent),
+                placement: 'auto'
+            });
+        }
+    });
+}
+
+function mostrarResumoAgendamentos(dataStr) {
+    diaResumoAtual = dataStr;
+    const resumoDia = resumoOcupacoes[dataStr];
+    if (!resumoDia) return;
+
+    const modalEl = document.getElementById('modalResumoDia');
+    const modal = new bootstrap.Modal(modalEl);
+    const container = document.getElementById('conteudoResumoDia');
+
+    document.getElementById('modalResumoDiaLabel').textContent = '📊 Resumo de Ocupação – ' + formatarData(dataStr);
+    container.innerHTML = '';
+
+    ['Manhã', 'Tarde', 'Noite'].forEach(turno => {
+        const info = resumoDia[turno];
+        if (!info) return;
+
+        const ocupacoesTurno = calendar.getEvents().filter(ev =>
+            ev.extendedProps.data === dataStr && ev.extendedProps.turno === turno
+        );
+
+        const card = document.createElement('div');
+        card.className = 'card mb-3';
+
+        const header = document.createElement('div');
+        header.className = 'card-header bg-light d-flex justify-content-between align-items-center';
+        header.innerHTML = `
+            <h6 class="mb-0">${escapeHTML(turno)}</h6>
+            <span class="badge bg-secondary">${escapeHTML(info.ocupadas)} / ${escapeHTML(info.total_salas)} Salas</span>
+        `;
+        card.appendChild(header);
+
+        const body = document.createElement('div');
+        body.className = 'card-body';
+
+        let htmlCorpo = '<div class="row">';
+
+        htmlCorpo += '<div class="col-md-7">';
+        htmlCorpo += '<h6><i class="bi bi-door-closed-fill text-danger"></i> Laboratórios Ocupados:</h6>';
+        if (ocupacoesTurno.length) {
+            htmlCorpo += '<ul class="list-group list-group-flush">';
+            ocupacoesTurno.forEach(ev => {
+                const props = ev.extendedProps;
+                const instr = props.instrutor_nome ? `<br><small class="text-muted"><i class="bi bi-person"></i> ${escapeHTML(props.instrutor_nome)}</small>` : '';
+                htmlCorpo += `
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <div>
+                            <strong>${escapeHTML(props.sala_nome)}:</strong> ${escapeHTML(props.curso_evento)}
+                            ${instr}
+                        </div>
+                        <div class="btn-group">
+                            <button class="btn btn-sm btn-outline-primary btn-editar-ocupacao" title="Editar" data-id="${ev.id}">
+                                <i class="bi bi-pencil"></i>
+                            </button>
+                            <button class="btn btn-sm btn-outline-danger btn-excluir-ocupacao" title="Excluir" data-id="${ev.id}" data-nome="${escapeHTML(props.curso_evento)}" data-grupo-id="${props.grupo_ocupacao_id || ''}">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </div>
+                    </li>
+                `;
+            });
+            htmlCorpo += '</ul>';
+        } else {
+            htmlCorpo += '<p class="fst-italic text-muted">Nenhum laboratório ocupado neste turno.</p>';
+        }
+        htmlCorpo += '</div>';
+
+        htmlCorpo += '<div class="col-md-5">';
+        htmlCorpo += '<h6><i class="bi bi-door-open-fill text-success"></i> Laboratórios Livres:</h6>';
+        if (info.salas_livres.length) {
+            info.salas_livres.forEach(salaNome => {
+                htmlCorpo += `<span class="badge bg-light text-dark border me-1 mb-1">${escapeHTML(salaNome)}</span>`;
+            });
+        } else {
+            htmlCorpo += '<p class="fst-italic text-muted">Todos os laboratórios estão ocupados.</p>';
+        }
+        htmlCorpo += '</div>';
+
+        htmlCorpo += '</div>';
+
+        body.innerHTML = sanitizeHTML(htmlCorpo);
+        card.appendChild(body);
+        container.appendChild(card);
+    });
+
+    container.querySelectorAll('.btn-editar-ocupacao').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            const ocupacaoId = e.currentTarget.getAttribute('data-id');
+            editarOcupacao(ocupacaoId);
+        });
+    });
+
+    container.querySelectorAll('.btn-excluir-ocupacao').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            const el = e.currentTarget;
+            const ocupacaoId = el.getAttribute('data-id');
+            const nome = el.getAttribute('data-nome');
+            const grupoId = el.getAttribute('data-grupo-id');
+            excluirOcupacao(ocupacaoId, nome, grupoId);
+        });
+    });
+
+    modal.show();
+}
+
+// Carrega salas para filtro
+async function carregarLaboratoriosParaFiltro() {
+    try {
+        const response = await fetch(`${API_URL}/laboratorios?status=ativa`, {
+            headers: {
+                'Authorization': `Bearer ${getToken()}`
+            }
+        });
+        
+        if (response.ok) {
+            salasData = await response.json();
+            
+            const select = document.getElementById('filtroLaboratorio');
+            select.innerHTML = '<option value="">Todos os laboratórios</option>';
+            
+            salasData.forEach(sala => {
+                select.innerHTML += `<option value="${sala.id}">${sala.nome}</option>`;
+            });
+        }
+    } catch (error) {
+        console.error('Erro ao carregar salas:', error);
+    }
+}
+
+// Carrega instrutores para filtro
+
+// Carrega tipos de ocupação
+async function carregarTiposOcupacao() {
+    try {
+        const response = await fetch(`${API_URL}/ocupacoes/tipos`, {
+            headers: {
+                'Authorization': `Bearer ${getToken()}`
+            }
+        });
+        
+        if (response.ok) {
+            tiposOcupacao = await response.json();
+        }
+    } catch (error) {
+        console.error('Erro ao carregar tipos de ocupação:', error);
+    }
+}
+
+// Aplica filtros no calendário
+function aplicarFiltrosCalendario() {
+    if (calendar) {
+        calendar.refetchEvents();
+    }
+}
+
+// Configura formulários de filtros (desktop e mobile)
 function configurarFiltros() {
-    const form = document.getElementById('filtrosForm') || document.querySelector('form');
+    const form = document.getElementById('filtrosForm');
+    const formMobile = document.getElementById('filtrosMobileForm');
+
     if (form) {
-        form.addEventListener('submit', function(e) {
+        form.addEventListener('submit', e => {
             e.preventDefault();
+            document.getElementById('filtroLaboratorioMobile').value = document.getElementById('filtroLaboratorio').value;
+            document.getElementById('filtroTurnoMobile').value = document.getElementById('filtroTurno').value;
+            aplicarFiltrosCalendario();
+        });
+    }
+
+    if (formMobile) {
+        formMobile.addEventListener('submit', e => {
+            e.preventDefault();
+            document.getElementById('filtroLaboratorio').value = document.getElementById('filtroLaboratorioMobile').value;
+            document.getElementById('filtroTurno').value = document.getElementById('filtroTurnoMobile').value;
             aplicarFiltrosCalendario();
         });
     }
 }
 
-async function aplicarFiltrosCalendario() {
-    if (!calendar) return;
+// Aplica filtros da URL (quando vem de outras páginas)
+function aplicarFiltrosURL() {
+    const urlParams = new URLSearchParams(window.location.search);
 
-    const loadingEl = document.getElementById('loadingCalendario');
-    if(loadingEl) loadingEl.style.display = 'block';
+    const laboratorioId = urlParams.get("laboratorio");
+    const turnoParam = urlParams.get("turno");
+    const mesParam = urlParams.get("mes");
 
-    try {
-        const params = new URLSearchParams({
-            data_inicio: calendar.view.activeStart.toISOString().slice(0, 10),
-            data_fim: calendar.view.activeEnd.toISOString().slice(0, 10),
-        });
+    if (laboratorioId) {
+        document.getElementById("filtroLaboratorio").value = laboratorioId;
+    }
 
-        // Adaptação para os filtros de Agendamento
-        const laboratorio = document.getElementById('filtroLaboratorio').value;
-        const turno = document.getElementById('filtroTurno').value;
-        if (laboratorio) params.append('laboratorio', laboratorio);
-        if (turno) params.append('turno', turno);
+    if (turnoParam) {
+        document.getElementById("filtroTurno").value = turnoParam;
+    }
 
-        // Chamada à API correta
-        const data = await chamarAPI(`/agendamentos/resumo-calendario?${params.toString()}`);
-        
-        if (data && data.resumo) {
-            renderizarPillulas(data.resumo, data.total_recursos);
-        }
-        
-    } catch (error) {
-        console.error("Erro ao aplicar filtros e buscar resumo:", error);
-        exibirAlerta("Não foi possível carregar os dados do calendário.", "danger");
-    } finally {
-        if(loadingEl) loadingEl.style.display = 'none';
+    if (mesParam && calendar) {
+        const dataMes = new Date(mesParam + "-01");
+        calendar.gotoDate(dataMes);
+    }
+
+    if (laboratorioId || turnoParam) {
+        setTimeout(() => aplicarFiltrosCalendario(), 1000);
     }
 }
 
-function renderizarPillulas(resumo, totalRecursos) {
-    document.querySelectorAll('.day-pills-container').forEach(container => {
-        const dataStr = container.getAttribute('data-date');
-        const diaResumo = resumo ? resumo[dataStr] : null;
-        let html = '';
+// Mostra detalhes da ocupação
+function mostrarDetalhesAgendamento(ocupacao) {
+    const modal = new bootstrap.Modal(document.getElementById('modalDetalhesAgendamento'));
+    
+    // Preenche conteúdo do modal
+    const content = document.getElementById('detalhesAgendamentoContent');
+    const acoes = document.getElementById('acoesAgendamento');
+    
+    const tipoNome = tiposOcupacao.find(t => t.valor === ocupacao.tipo_ocupacao)?.nome || ocupacao.tipo_ocupacao;
+    const salaNome = salasData.find(s => s.id === ocupacao.sala_id)?.nome || 'Sala não encontrada';
+    const instrutorNome = ocupacao.instrutor_id ? 
+        (instrutoresData.find(i => i.id === ocupacao.instrutor_id)?.nome || 'Instrutor não encontrado') : 
+        'Nenhum instrutor';
+    
+    content.innerHTML = `
+        <div class="row">
+            <div class="col-md-6">
+                <h6>Curso/Evento</h6>
+                <p class="mb-3">${ocupacao.curso_evento}</p>
+                
+                <h6>Tipo</h6>
+                <p class="mb-3">
+                    <span class="badge" style="background-color: ${getTipoCorPorValor(ocupacao.tipo_ocupacao)};">
+                        ${tipoNome}
+                    </span>
+                </p>
+                
+                <h6>Status</h6>
+                <p class="mb-3">
+                    <span class="badge ${getStatusBadgeClass(ocupacao.status)}">
+                        ${getStatusNome(ocupacao.status)}
+                    </span>
+                </p>
+            </div>
+            <div class="col-md-6">
+                <h6>Data e Horário</h6>
+                <p class="mb-3">
+                    <i class="bi bi-calendar me-1"></i>
+                    ${formatarData(ocupacao.data)}<br>
+                    <i class="bi bi-clock me-1"></i>
+                    ${ocupacao.horario_inicio} às ${ocupacao.horario_fim}
+                </p>
+                
+                <h6>Sala</h6>
+                <p class="mb-3">
+                    <i class="bi bi-building me-1"></i>
+                    ${salaNome}
+                </p>
+                
+                <h6>Instrutor</h6>
+                <p class="mb-3">
+                    <i class="bi bi-person-badge me-1"></i>
+                    ${instrutorNome}
+                </p>
+            </div>
+        </div>
+        
+        ${ocupacao.observacoes ? `
+            <div class="row">
+                <div class="col-12">
+                    <h6>Observações</h6>
+                    <p class="mb-0">${ocupacao.observacoes}</p>
+                </div>
+            </div>
+        ` : ''}
+    `;
+    
+    // Configura ações baseadas nas permissões
+    const usuario = getUsuarioLogado();
+    const podeEditar = isAdmin() || ocupacao.usuario_id === usuario.id;
+    
+    acoes.innerHTML = '';
+    
+    if (podeEditar) {
+        const btnEditar = document.createElement('button');
+        btnEditar.type = 'button';
+        btnEditar.className = 'btn btn-primary me-2';
+        btnEditar.innerHTML = '<i class="bi bi-pencil me-1"></i>Editar';
+        btnEditar.addEventListener('click', () => editarOcupacao(ocupacao.id));
 
-        if (totalRecursos > 0) {
-            ['Manhã', 'Tarde', 'Noite'].forEach(turno => {
-                const ocupados = diaResumo && diaResumo[turno] ? diaResumo[turno].ocupados : 0;
-                
-                let statusClass = 'turno-livre'; // Padrão é livre
-                if (ocupados > 0) {
-                    statusClass = ocupados >= totalRecursos ? 'turno-cheio' : 'turno-parcial';
-                }
-                
-                html += `<div class="pill-turno ${statusClass}">${turno}: ${ocupados}/${totalRecursos}</div>`;
-            });
-        }
-        container.innerHTML = html;
+        const btnExcluir = document.createElement('button');
+        btnExcluir.type = 'button';
+        btnExcluir.className = 'btn btn-danger';
+        btnExcluir.innerHTML = '<i class="bi bi-trash me-1"></i>Excluir';
+        btnExcluir.addEventListener('click', () => excluirOcupacao(ocupacao.id, ocupacao.curso_evento, ocupacao.grupo_ocupacao_id || ''));
+
+        acoes.appendChild(btnEditar);
+        acoes.appendChild(btnExcluir);
+    }
+    
+    modal.show();
+}
+
+// Retorna cor do tipo por valor
+function getTipoCorPorValor(valor) {
+    const tipo = tiposOcupacao.find(t => t.valor === valor);
+    return tipo ? tipo.cor : '#6c757d';
+}
+
+// Retorna classe do badge de status
+function getStatusBadgeClass(status) {
+    const classes = {
+        'confirmado': 'bg-success',
+        'pendente': 'bg-warning',
+        'cancelado': 'bg-danger'
+    };
+    return classes[status] || 'bg-secondary';
+}
+
+// Retorna nome do status
+function getStatusNome(status) {
+    const nomes = {
+        'confirmado': 'Confirmado',
+        'pendente': 'Pendente',
+        'cancelado': 'Cancelado'
+    };
+    return nomes[status] || status;
+}
+
+// Formata data para exibição
+function formatarData(dataStr) {
+    const data = new Date(dataStr + 'T00:00:00');
+    return data.toLocaleDateString('pt-BR', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
     });
 }
+
+// Edita ocupação
+function editarOcupacao(id) {
+    // Fecha modais abertos antes de redirecionar
+    const detalhesEl = document.getElementById('modalDetalhesAgendamento');
+    const detalhesModal = detalhesEl ? bootstrap.Modal.getInstance(detalhesEl) : null;
+    if (detalhesModal) detalhesModal.hide();
+
+    const resumoEl = document.getElementById('modalResumoDia');
+    const resumoModal = resumoEl ? bootstrap.Modal.getInstance(resumoEl) : null;
+    if (resumoModal) resumoModal.hide();
+
+    // Redireciona para edição (implementar página de edição)
+    window.location.href = `/novo-agendamento-sala.html?editar=${id}`;
+}
+
+// Exclui ocupação a partir do resumo do dia
+function excluirOcupacaoResumo(id) {
+    const evento = calendar.getEventById(id);
+    if (!evento) return;
+    const props = evento.extendedProps;
+    excluirOcupacao(id, props.curso_evento, props.grupo_ocupacao_id || '');
+}
+
+// Exclui ocupação
+function excluirOcupacao(id, nome, grupoId) {
+    // Fecha modais que possam estar abertos
+    const detalhesEl = document.getElementById('modalDetalhesAgendamento');
+    const detalhesModal = detalhesEl ? bootstrap.Modal.getInstance(detalhesEl) : null;
+    if (detalhesModal) detalhesModal.hide();
+
+    const resumoEl = document.getElementById('modalResumoDia');
+    const resumoModal = resumoEl ? bootstrap.Modal.getInstance(resumoEl) : null;
+    if (resumoModal) resumoModal.hide();
+
+    // Configura modal de exclusão
+    document.getElementById('resumoAgendamentoExcluir').textContent = nome;
+    const modalEl = document.getElementById('modalExcluirAgendamento');
+    modalEl.setAttribute('data-ocupacao-id', id);
+    modalEl.setAttribute('data-grupo-id', grupoId);
+    
+    // Mostra modal de confirmação
+    const modalExcluir = new bootstrap.Modal(document.getElementById('modalExcluirAgendamento'));
+    modalExcluir.show();
+}
+
+// Confirma exclusão da ocupação
+async function confirmarExclusaoOcupacao(modo) {
+    try {
+        const modalEl = document.getElementById('modalExcluirAgendamento');
+        const ocupacaoId = modalEl.getAttribute('data-ocupacao-id');
+        const grupoId = modalEl.getAttribute('data-grupo-id');
+        const somenteDia = modo === 'dia';
+
+        const url = somenteDia ?
+            `${API_URL}/ocupacoes/${ocupacaoId}?somente_dia=true` :
+            `${API_URL}/ocupacoes/${ocupacaoId}`;
+
+        const response = await fetch(url, {
+            method: 'DELETE',
+            headers: {
+                'Authorization': `Bearer ${getToken()}`
+            }
+        });
+        
+        const result = await response.json();
+        
+        if (response.ok) {
+            exibirAlerta('Ocupação excluída com sucesso!', 'success');
+
+            // Fecha o modal
+            const modal = bootstrap.Modal.getInstance(document.getElementById('modalExcluirAgendamento'));
+            modal.hide();
+
+            // Remove evento imediatamente e atualiza dados
+            const ev = calendar.getEventById(ocupacaoId);
+            if (ev) ev.remove();
+            calendar.refetchEvents();
+            await carregarResumoPeriodo(
+                calendar.view.activeStart.toISOString().split('T')[0],
+                calendar.view.activeEnd.toISOString().split('T')[0]
+            );
+            if (diaResumoAtual) {
+                mostrarResumoAgendamentos(diaResumoAtual);
+            }
+        } else {
+            throw new Error(result.erro || 'Erro ao excluir ocupação');
+        }
+    } catch (error) {
+        console.error('Erro ao excluir ocupação:', error);
+        exibirAlerta(error.message, 'danger');
+    }
+}
+
+// Função para exibir alertas
+function exibirAlerta(mensagem, tipo) {
+    // Remove alertas existentes
+    const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
+    alertasExistentes.forEach(alerta => alerta.remove());
+
+    // Cria novo alerta
+    const alerta = document.createElement('div');
+    alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
+    alerta.textContent = mensagem;
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close';
+    closeBtn.setAttribute('data-bs-dismiss', 'alert');
+    closeBtn.setAttribute('aria-label', 'Close');
+    alerta.appendChild(closeBtn);
+    
+    // Insere no início do main
+    const main = document.querySelector('main');
+    main.insertBefore(alerta, main.firstChild);
+    
+    // Remove automaticamente após 5 segundos
+    setTimeout(() => {
+        if (alerta.parentNode) {
+            alerta.remove();
+        }
+    }, 5000);
+}
+
+function formatarDataCurta(dataStr) {
+    const data = new Date(dataStr + 'T00:00:00');
+    return data.toLocaleDateString('pt-BR', {
+        day: '2-digit',
+        month: '2-digit'
+    });
+}
+


### PR DESCRIPTION
## Summary
- sincroniza o HTML do calendário de agendamentos com o de ocupações
- adapta links, textos e filtros para Laboratórios
- substitui código JS pelo de calendário de salas com ajustes para agendamentos

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686710fa44888323ab932ed89a35b30e