### PR TITLE
Atualiza links para nova página de calendário

### DIFF
--- a/src/static/calendario-agendamentos-v2.html
+++ b/src/static/calendario-agendamentos-v2.html
@@ -29,7 +29,7 @@
                             <i class="bi bi-speedometer2 me-1"></i> Dashboard
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link active" href="/calendario.html">
                             <i class="bi bi-calendar3 me-1"></i> Calendário
                     </li>
                     <li class="nav-item">

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -29,7 +29,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3 me-1"></i> Calendário
                         </a>
                     </li>
@@ -75,7 +75,7 @@
                         <a class="nav-link active" href="/index.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
                         <a class="nav-link" href="/novo-agendamento.html">
@@ -115,7 +115,7 @@
                             <div class="card-footer text-end">
                                 <button class="btn btn-sm btn-outline-secondary me-2" onclick="exportarDados('/agendamentos/export','csv','agendamentos')">CSV</button>
                                 <button class="btn btn-sm btn-outline-secondary me-2" onclick="exportarDados('/agendamentos/export','pdf','agendamentos')">PDF</button>
-                                <a href="/calendario-agendamentos-v2.html" class="btn btn-sm btn-outline-primary">Ver Calendário</a>
+                                <a href="/calendario.html" class="btn btn-sm btn-outline-primary">Ver Calendário</a>
                             </div>
                         </div>
                     </div>

--- a/src/static/laboratorios-turmas.html
+++ b/src/static/laboratorios-turmas.html
@@ -29,7 +29,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3 me-1"></i> Calendário
                         </a>
                     </li>
@@ -80,7 +80,7 @@
                         <a class="nav-link" href="/index.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
                         <a class="nav-link" href="/novo-agendamento.html">

--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -29,7 +29,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3 me-1"></i> Calendário
                         </a>
                     </li>
@@ -80,7 +80,7 @@
                         <a class="nav-link" href="/index.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
                         <a class="nav-link active" href="/novo-agendamento.html">
@@ -155,7 +155,7 @@
                             </div>
                             
                             <div class="d-flex justify-content-between">
-                                <a href="/calendario-agendamentos-v2.html" class="btn btn-secondary">
+                                <a href="/calendario.html" class="btn btn-secondary">
                                     <i class="bi bi-arrow-left me-2"></i>Voltar
                                 </a>
                                 <button type="submit" class="btn btn-primary" id="btnSalvar">
@@ -307,7 +307,7 @@
                     
                     // Redireciona após 2 segundos
                     setTimeout(() => {
-                        window.location.href = '/calendario-agendamentos-v2.html';
+                        window.location.href = '/calendario.html';
                     }, 2000);
                 } catch (error) {
                     if (error.message.includes('Conflito de horários')) {

--- a/src/static/perfil.html
+++ b/src/static/perfil.html
@@ -29,7 +29,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3 me-1"></i> Calendário
                         </a>
                     </li>
@@ -75,7 +75,7 @@
                         <a class="nav-link" href="/index.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
-                        <a class="nav-link" href="/calendario-agendamentos-v2.html">
+                        <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
                         <a class="nav-link" href="/novo-agendamento.html">


### PR DESCRIPTION
## Summary
- update navigation links to use `/calendario.html`
- keep calendar link active in old calendar page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6868077de24c8323802c800b00612437