### PR TITLE
Restaurar calendario.html

### DIFF
--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -1,22 +1,111 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calendário de Agendamentos - Sistema de Agenda de Laboratório</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container-fluid">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                Sistema de Agenda de Laboratório
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/index.html">
+                            <i class="bi bi-speedometer2 me-1"></i> Dashboard
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active" href="/calendario.html">
+                            <i class="bi bi-calendar3 me-1"></i> Calendário
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/novo-agendamento.html">
+                            <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
+                        </a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/laboratorios-turmas.html">
+                            <i class="bi bi-building me-1"></i> Laboratórios e Turmas
+                        </a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i>
+                            <span id="userName">Usuário</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li><a class="dropdown-item" href="/perfil.html"><i class="bi bi-person me-2"></i>Meu Perfil</a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" href="#" id="btnLogout"><i class="bi bi-box-arrow-right me-2"></i>Sair</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container-fluid py-4">
         <div class="row">
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <h5 class="mb-3">Menu Principal</h5>
+                    <div class="nav flex-column">
+                        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2"></i> Dashboard</a>
+                        <a class="nav-link active" href="/calendario.html"><i class="bi bi-calendar3"></i> Calendário</a>
+                        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle"></i> Novo Agendamento</a>
+                        <a class="nav-link admin-only" href="/laboratorios-turmas.html"><i class="bi bi-building"></i> Laboratórios e Turmas</a>
+                        <a class="nav-link" href="/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                    </div>
+                    <hr>
+                    <h5 class="mb-3">Filtros</h5>
+                    <form id="filtrosForm">
+                        <div class="mb-3">
+                            <label for="filtroLaboratorio" class="form-label">Laboratório</label>
+                            <select class="form-select" id="filtroLaboratorio">
+                                <option value="">Todos os laboratórios</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="filtroTurno" class="form-label">Turno</label>
+                            <select class="form-select" id="filtroTurno">
+                                <option value="">Todos</option>
+                                <option value="Manhã">Manhã</option>
+                                <option value="Tarde">Tarde</option>
+                                <option value="Noite">Noite</option>
+                            </select>
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100"><i class="bi bi-funnel me-2"></i>Filtrar</button>
+                    </form>
+                </div>
+            </div>
+
             <main class="col-lg-9">
                 <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap">
                     <div>
                         <h2 class="text-uppercase mb-0">Calendário de Agendamentos</h2>
-                        <h5 id="periodo-header" class="text-muted fw-normal">Julho de 2025</h5>
+                        <h5 id="periodo-header" class="text-muted fw-normal"></h5>
                     </div>
                     <div class="d-flex align-items-center mt-2 mt-md-0">
                         <div class="btn-group me-3" role="group">
-                            <button id="nav-anterior" class="btn btn-outline-primary"><i class="bi bi-chevron-left"></i></button>
+                            <button id="nav-anterior" class="btn btn-outline-primary" title="Anterior"><i class="bi bi-chevron-left"></i></button>
                             <button id="nav-hoje" class="btn btn-outline-secondary">Hoje</button>
-                            <button id="nav-seguinte" class="btn btn-outline-primary"><i class="bi bi-chevron-right"></i></button>
+                            <button id="nav-seguinte" class="btn btn-outline-primary" title="Próximo"><i class="bi bi-chevron-right"></i></button>
                         </div>
                         <div class="btn-group" role="group">
                             <input type="radio" class="btn-check" name="view-toggle" id="view-mensal" autocomplete="off" checked>
@@ -33,11 +122,17 @@
 
                 <div id="visao-mensal-container">
                     </div>
-
                 <div id="visao-semanal-container" class="table-responsive" style="display: none;">
                     </div>
             </main>
         </div>
     </div>
-    <script src="/js/calendario-hibrido.js"></script> </body>
+    
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/locales/pt-br.global.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/calendario-hibrido.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- restore HTML for calendar interface with navbar, sidebar, filters and containers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68680c5ddbac83238ff78c77f1abe726