### PR TITLE
Fix mini calendar colors and show schedule times

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -1125,3 +1125,28 @@ input, select, textarea {
 .agendamento-info strong { color: #333; }
 .agendamento-info span { font-size: 0.9em; color: #6c757d; }
 .btn-novo-agendamento-turno { font-weight: 500; }
+
+/* ======================================================= */
+/* == CORREÇÃO VISUAL PARA O MINI-CALENDÁRIO              == */
+/* ======================================================= */
+
+#mini-calendario .fc-daygrid-day-number {
+    color: #333 !important; /* Garante que o número do dia seja visível */
+    text-decoration: none !important;
+    padding: 4px;
+}
+
+#mini-calendario .fc-day-today .fc-daygrid-day-number {
+    color: #fff !important; /* Cor do número do dia "hoje" */
+    background-color: #00539F; /* Fundo azul para o dia "hoje" */
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    display: inline-block;
+    line-height: 16px;
+    text-align: center;
+}
+
+#mini-calendario .fc-daygrid-day-frame:hover {
+    background-color: #f0f0f0;
+}

--- a/src/static/js/agenda-diaria.js
+++ b/src/static/js/agenda-diaria.js
@@ -95,8 +95,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                         ? agendamentosDoTurno.map(ag => `
                             <div class="agendamento-item">
                                 <div class="agendamento-info">
-                                    <strong>${escapeHTML(ag.turma_nome)}</strong><br>
-                                    <span class="text-muted">${ag.horario_inicio} - ${ag.horario_fim}</span>
+                                    <strong>${escapeHTML(ag.turma_nome)}</strong>
+                                    <br>
+                                    <span class="text-muted small">
+                                        <i class="bi bi-clock"></i> 
+                                        ${ag.horario_inicio} - ${ag.horario_fim}
+                                    </span>
                                 </div>
                                 <div class="agendamento-acoes btn-group">
                                     <button class="btn btn-sm btn-outline-primary" onclick="window.location.href='/novo-agendamento.html?id=${ag.id}'" title="Editar"><i class="bi bi-pencil"></i></button>


### PR DESCRIPTION
## Summary
- ensure mini-calendar days always visible
- show schedule start and end times with clock icon in agenda view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68682a1b3a98832389a35ceab17a3a02