### PR TITLE
Atualiza agenda diaria com helper

### DIFF
--- a/src/routes/agendamento.py
+++ b/src/routes/agendamento.py
@@ -457,6 +457,7 @@ def agenda_diaria():
             'turma_nome': ag.turma,
             'horario_inicio': horarios[0] if horarios else None,
             'horario_fim': horarios[-1] if horarios else None,
+            'horarios': json.dumps(horarios)
         }
         ag_por_turno.setdefault(ag.turno, []).append(info)
 

--- a/src/static/js/agenda-diaria.js
+++ b/src/static/js/agenda-diaria.js
@@ -1,3 +1,16 @@
+// FUNÇÃO AUXILIAR PARA CALCULAR O INTERVALO DE TEMPO
+function calcularIntervaloDeTempo(horarios) {
+    if (!horarios || horarios.length === 0) {
+        return '';
+    }
+    // Extrai todos os horários de início e fim
+    const tempos = horarios.flatMap(h => h.split(' - '));
+    // Encontra o primeiro horário de início e o último de fim
+    const inicio = tempos[0];
+    const fim = tempos[tempos.length - 1];
+    return `${inicio} - ${fim}`;
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
     if (!verificarAutenticacao()) return;
 
@@ -91,23 +104,27 @@ document.addEventListener('DOMContentLoaded', async () => {
             <div class="card turno-card">
                 <div class="card-header">> ${turno}</div>
                 <div class="card-body">
-                    ${agendamentosDoTurno.length > 0 
-                        ? agendamentosDoTurno.map(ag => `
+                    ${agendamentosDoTurno.length > 0
+                        ? agendamentosDoTurno.map(ag => {
+                            // Chama a nova função para obter o intervalo de tempo formatado
+                            const intervaloDeTempo = calcularIntervaloDeTempo(JSON.parse(ag.horarios || '[]'));
+
+                            return `
                             <div class="agendamento-item">
                                 <div class="agendamento-info">
                                     <strong>${escapeHTML(ag.turma_nome)}</strong>
                                     <br>
                                     <span class="text-muted small">
                                         <i class="bi bi-clock"></i> 
-                                        ${ag.horario_inicio} - ${ag.horario_fim}
-                                    </span>
+                                        ${intervaloDeTempo}  </span>
                                 </div>
                                 <div class="agendamento-acoes btn-group">
                                     <button class="btn btn-sm btn-outline-primary" onclick="window.location.href='/novo-agendamento.html?id=${ag.id}'" title="Editar"><i class="bi bi-pencil"></i></button>
                                     <button class="btn btn-sm btn-outline-danger" onclick="excluirAgendamento(${ag.id})" title="Excluir"><i class="bi bi-trash"></i></button>
                                 </div>
                             </div>
-                        `).join('') 
+                            `;
+                        }).join('')
                         : '<p class="text-muted small">Nenhum agendamento neste turno.</p>'
                     }
                 </div>


### PR DESCRIPTION
## Summary
- add helper `calcularIntervaloDeTempo` in `agenda-diaria.js`
- render daily agenda using new interval helper
- expose `horarios` in `/api/agendamentos/agenda-diaria` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68683e722c78832392e47deca4acad48