### PR TITLE
Fix sidebar order and profile menu

### DIFF
--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -58,11 +58,21 @@
                 <div class="sidebar rounded shadow-sm">
                     <h5 class="mb-3">Menu Principal</h5>
                     <div class="nav flex-column">
-                        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2"></i> Dashboard</a>
-                        <a class="nav-link active" href="/calendario.html"><i class="bi bi-calendar3"></i> Calendário</a>
-                        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle"></i> Novo Agendamento</a>
-                        <a class="nav-link admin-only" href="/laboratorios-turmas.html"><i class="bi bi-building"></i> Laboratórios e Turmas</a>
-                        <a class="nav-link" href="/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                        <a class="nav-link" href="/index.html">
+                            <i class="bi bi-speedometer2"></i> Dashboard
+                        </a>
+                        <a class="nav-link active" href="/calendario.html">
+                            <i class="bi bi-calendar3"></i> Calendário
+                        </a>
+                        <a class="nav-link admin-only" href="/laboratorios-turmas.html">
+                            <i class="bi bi-building"></i> Laboratórios e Turmas
+                        </a>
+                        <a class="nav-link" href="/novo-agendamento.html">
+                            <i class="bi bi-plus-circle"></i> Novo Agendamento
+                        </a>
+                        <a class="nav-link" href="/perfil.html">
+                            <i class="bi bi-person"></i> Meu Perfil
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -78,6 +78,9 @@
                         <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
+                        <a class="nav-link admin-only" href="/laboratorios-turmas.html">
+                            <i class="bi bi-building"></i> Laboratórios e Turmas
+                        </a>
                         <a class="nav-link" href="/novo-agendamento.html">
                             <i class="bi bi-plus-circle"></i> Novo Agendamento
                         </a>

--- a/src/static/laboratorios-turmas.html
+++ b/src/static/laboratorios-turmas.html
@@ -83,11 +83,11 @@
                         <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
-                        <a class="nav-link" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle"></i> Novo Agendamento
-                        </a>
                         <a class="nav-link active admin-only" href="/laboratorios-turmas.html">
                             <i class="bi bi-building"></i> Laboratórios e Turmas
+                        </a>
+                        <a class="nav-link" href="/novo-agendamento.html">
+                            <i class="bi bi-plus-circle"></i> Novo Agendamento
                         </a>
                         <a class="nav-link" href="/perfil.html">
                             <i class="bi bi-person"></i> Meu Perfil

--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -83,11 +83,11 @@
                         <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
-                        <a class="nav-link active" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle"></i> Novo Agendamento
-                        </a>
                         <a class="nav-link admin-only" href="/laboratorios-turmas.html">
                             <i class="bi bi-building"></i> Laboratórios e Turmas
+                        </a>
+                        <a class="nav-link active" href="/novo-agendamento.html">
+                            <i class="bi bi-plus-circle"></i> Novo Agendamento
                         </a>
                         <a class="nav-link" href="/perfil.html">
                             <i class="bi bi-person"></i> Meu Perfil

--- a/src/static/perfil.html
+++ b/src/static/perfil.html
@@ -78,6 +78,9 @@
                         <a class="nav-link" href="/calendario.html">
                             <i class="bi bi-calendar3"></i> Calendário
                         </a>
+                        <a class="nav-link admin-only" href="/laboratorios-turmas.html">
+                            <i class="bi bi-building"></i> Laboratórios e Turmas
+                        </a>
                         <a class="nav-link" href="/novo-agendamento.html">
                             <i class="bi bi-plus-circle"></i> Novo Agendamento
                         </a>


### PR DESCRIPTION
## Summary
- reorder sidebar links
- add missing "Laboratórios e Turmas" link to profile page sidebar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6868493a375083239108af63e107f14f