### PR TITLE
Fix navbar order and daily agenda title

### DIFF
--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -22,19 +22,20 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2 me-1"></i> Dashboard</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link active" href="/calendario.html"><i class="bi bi-calendar3 me-1"></i> Calendário</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle me-1"></i> Novo Agendamento</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/laboratorios-turmas.html"><i class="bi bi-building me-1"></i> Laboratórios e Turmas</a>
-                    </li>
-                </ul>
+    <li class="nav-item">
+        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2 me-1"></i> Dashboard</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link active" href="/calendario.html"><i class="bi bi-calendar3 me-1"></i> Calendário</a>
+    </li>
+    <li class="nav-item admin-only">
+        <a class="nav-link" href="/laboratorios-turmas.html"><i class="bi bi-building me-1"></i> Laboratórios e Turmas</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle me-1"></i> Novo Agendamento</a>
+    </li>
+</ul>
+
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -84,7 +85,7 @@
                 </div>
                 
                 <div id="agenda-content" style="display: none;">
-                    <h2 class="text-uppercase mb-4">> Agenda Diária de Laboratórios</h2>
+                    <h2 class="text-uppercase mb-4">AGENDA DIÁRIA DE LABORATÓRIOS</h2>
                     
                     <div class="card mb-4">
                         <div class="card-body">

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -23,22 +23,20 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link active" href="/index.html">
-                            <i class="bi bi-speedometer2 me-1"></i> Dashboard
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/calendario.html">
-                            <i class="bi bi-calendar3 me-1"></i> Calendário
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
-                        </a>
-                    </li>
-                </ul>
+    <li class="nav-item">
+        <a class="nav-link active" href="/index.html"><i class="bi bi-speedometer2 me-1"></i> Dashboard</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/calendario.html"><i class="bi bi-calendar3 me-1"></i> Calendário</a>
+    </li>
+    <li class="nav-item admin-only">
+        <a class="nav-link" href="/laboratorios-turmas.html"><i class="bi bi-building me-1"></i> Laboratórios e Turmas</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle me-1"></i> Novo Agendamento</a>
+    </li>
+</ul>
+
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/src/static/laboratorios-turmas.html
+++ b/src/static/laboratorios-turmas.html
@@ -23,27 +23,20 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/index.html">
-                            <i class="bi bi-speedometer2 me-1"></i> Dashboard
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/calendario.html">
-                            <i class="bi bi-calendar3 me-1"></i> Calendário
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
-                        </a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link active" href="/laboratorios-turmas.html">
-                            <i class="bi bi-building me-1"></i> Laboratórios e Turmas
-                        </a>
-                    </li>
-                </ul>
+    <li class="nav-item">
+        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2 me-1"></i> Dashboard</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/calendario.html"><i class="bi bi-calendar3 me-1"></i> Calendário</a>
+    </li>
+    <li class="nav-item admin-only">
+        <a class="nav-link active" href="/laboratorios-turmas.html"><i class="bi bi-building me-1"></i> Laboratórios e Turmas</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle me-1"></i> Novo Agendamento</a>
+    </li>
+</ul>
+
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -23,27 +23,20 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/index.html">
-                            <i class="bi bi-speedometer2 me-1"></i> Dashboard
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/calendario.html">
-                            <i class="bi bi-calendar3 me-1"></i> Calendário
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link active" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
-                        </a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/laboratorios-turmas.html">
-                            <i class="bi bi-building me-1"></i> Laboratórios e Turmas
-                        </a>
-                    </li>
-                </ul>
+    <li class="nav-item">
+        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2 me-1"></i> Dashboard</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/calendario.html"><i class="bi bi-calendar3 me-1"></i> Calendário</a>
+    </li>
+    <li class="nav-item admin-only">
+        <a class="nav-link" href="/laboratorios-turmas.html"><i class="bi bi-building me-1"></i> Laboratórios e Turmas</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link active" href="/novo-agendamento.html"><i class="bi bi-plus-circle me-1"></i> Novo Agendamento</a>
+    </li>
+</ul>
+
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/src/static/perfil.html
+++ b/src/static/perfil.html
@@ -23,22 +23,20 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/index.html">
-                            <i class="bi bi-speedometer2 me-1"></i> Dashboard
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/calendario.html">
-                            <i class="bi bi-calendar3 me-1"></i> Calendário
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/novo-agendamento.html">
-                            <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
-                        </a>
-                    </li>
-                </ul>
+    <li class="nav-item">
+        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2 me-1"></i> Dashboard</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/calendario.html"><i class="bi bi-calendar3 me-1"></i> Calendário</a>
+    </li>
+    <li class="nav-item admin-only">
+        <a class="nav-link" href="/laboratorios-turmas.html"><i class="bi bi-building me-1"></i> Laboratórios e Turmas</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle me-1"></i> Novo Agendamento</a>
+    </li>
+</ul>
+
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
## Summary
- remove stray angle bracket in daily agenda title
- sync navbar across pages and set active links

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68686847c85483239bffe66becc0860a