### PR TITLE
Fix agenda deletion confirmation and hide empty slots

### DIFF
--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -109,6 +109,24 @@
         </div>
     </div>
     
+    <div class="modal fade" id="confirmarExclusaoModal" tabindex="-1" aria-labelledby="confirmarExclusaoModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="confirmarExclusaoModalLabel">Confirmar Exclusão</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <div class="modal-body">
+                    Tem a certeza que deseja excluir este agendamento? Esta ação não pode ser desfeita.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-danger" id="btnConfirmarExclusao">Sim, Excluir</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>

--- a/src/static/js/agenda-diaria.js
+++ b/src/static/js/agenda-diaria.js
@@ -18,13 +18,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!verificarAutenticacao()) return;
 
     // Variáveis de estado da página
-    let laboratorios = [];
-    let labSelecionadoId = null;
-    let dataSelecionada = new Date();
-    let miniCalendar;
+    let laboratorios = [], labSelecionadoId = null, dataSelecionada = new Date(), miniCalendar;
+    let agendamentoParaExcluirId = null;
 
     const loadingEl = document.getElementById('loading-page');
     const contentEl = document.getElementById('agenda-content');
+    const agendaContainer = document.getElementById('detalhes-dia-container');
+    const confirmacaoModal = new bootstrap.Modal(document.getElementById('confirmarExclusaoModal'));
 
     // Função de inicialização
     async function inicializarPagina() {
@@ -126,8 +126,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         document.getElementById('dia-destaque').textContent = dataSelecionada.getDate().toString().padStart(2, '0');
         document.getElementById('data-extenso-destaque').textContent = dataSelecionada.toLocaleDateString('pt-BR', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
         
-        const container = document.getElementById('detalhes-dia-container');
-        container.innerHTML = `<div class="text-center p-5"><div class="spinner-border spinner-border-sm"></div></div>`;
+        agendaContainer.innerHTML = `<div class="text-center p-5"><div class="spinner-border spinner-border-sm"></div></div>`;
 
         try {
             const dataFormatada = dataSelecionada.toISOString().split('T')[0];
@@ -135,56 +134,75 @@ document.addEventListener('DOMContentLoaded', async () => {
             renderizarDetalhesDia(dados.agendamentos_por_turno);
         } catch (error) {
             exibirAlerta('Erro ao carregar agenda diária.', 'danger');
-            container.innerHTML = '<p class="text-danger">Não foi possível carregar os agendamentos.</p>';
+            agendaContainer.innerHTML = '<p class="text-danger">Não foi possível carregar os agendamentos.</p>';
         }
     }
 
     function renderizarDetalhesDia(agendamentosPorTurno) {
-        const container = document.getElementById('detalhes-dia-container');
         const dataFormatada = dataSelecionada.toISOString().split('T')[0];
 
-        container.innerHTML = ['Manhã', 'Tarde', 'Noite'].map(turno => {
+        agendaContainer.innerHTML = ['Manhã', 'Tarde', 'Noite'].map(turno => {
             const dadosTurno = agendamentosPorTurno[turno] || { agendamentos: [], horarios_disponiveis: [] };
             const agendamentosDoTurno = dadosTurno.agendamentos;
             const horariosDisponiveis = dadosTurno.horarios_disponiveis;
 
             return `
-        <div class="card turno-card">
-            <div class="card-header">> ${turno.toUpperCase()}</div>
-            <div class="card-body">
-                ${agendamentosDoTurno.length > 0
-                    ? `<h6><i class="bi bi-calendar-x-fill"></i> Horários Ocupados</h6>` +
-                      agendamentosDoTurno.map(ag => `
-                        <div class="agendamento-item">
-                            <div class="agendamento-info">
-                                <strong>${escapeHTML(ag.turma_nome)}</strong><br>
-                                <span class="text-muted small">
-                                    <i class="bi bi-clock-fill"></i> 
-                                    ${calcularIntervaloDeTempo(ag.horarios)}
-                                </span>
+            <div class="card turno-card">
+                <div class="card-header">> ${turno.toUpperCase()}</div>
+                <div class="card-body">
+                    ${agendamentosDoTurno.length > 0
+                        ? `<h6><i class="bi bi-calendar-x-fill"></i> Horários Ocupados</h6>` +
+                          agendamentosDoTurno.map(ag => `
+                            <div class="agendamento-item">
+                                <div class="agendamento-info">
+                                    <strong>${escapeHTML(ag.turma_nome)}</strong><br>
+                                    <span class="text-muted small">
+                                        <i class="bi bi-clock-fill"></i> ${calcularIntervaloDeTempo(ag.horarios)}
+                                    </span>
+                                </div>
+                                <div class="agendamento-acoes btn-group">
+                                    <a href="/novo-agendamento.html?id=${ag.id}" class="btn btn-sm btn-outline-primary" title="Editar"><i class="bi bi-pencil"></i></a>
+                                    <button class="btn btn-sm btn-outline-danger" onclick="window.excluirAgendamento(${ag.id})" title="Excluir"><i class="bi bi-trash"></i></button>
+                                </div>
                             </div>
-                            <div class="agendamento-acoes btn-group">
-                                <a href="/novo-agendamento.html?id=${ag.id}" class="btn btn-sm btn-outline-primary" title="Editar"><i class="bi bi-pencil"></i></a>
-                                <button class="btn btn-sm btn-outline-danger" onclick="excluirAgendamento(${ag.id})" title="Excluir"><i class="bi bi-trash"></i></button>
-                            </div>
-                        </div>
-                      `).join('')
-                    : ''
-                }
-                
-                <h6 class="${agendamentosDoTurno.length > 0 ? 'mt-4' : ''}"><i class="bi bi-calendar-check-fill"></i> Horários Disponíveis</h6>
-                ${horariosDisponiveis.length > 0
-                    ? horariosDisponiveis.map(h => `<span class="badge bg-light text-dark border me-1 mb-1">${h}</span>`).join('')
-                    : '<p class="text-muted small">Todos os horários deste turno estão ocupados.</p>'
-                }
-            </div>
-            <div class="card-footer text-end">
-                <a href="/novo-agendamento.html?lab_id=${labSelecionadoId}&data=${dataFormatada}&turno=${turno}" class="btn btn-primary btn-sm btn-novo-agendamento-turno">
-                    <i class="bi bi-plus"></i> Novo Agendamento
-                </a>
-            </div>
-        </div>`;
+                          `).join('')
+                        : ''
+                    }
+                    
+                    ${horariosDisponiveis.length > 0
+                        ? `<h6 class="${agendamentosDoTurno.length > 0 ? 'mt-4' : ''}"><i class="bi bi-calendar-check-fill"></i> Horários Disponíveis</h6>` +
+                          horariosDisponiveis.map(h => `<span class="badge bg-light text-dark border me-1 mb-1">${h}</span>`).join('')
+                        : (agendamentosDoTurno.length === 0 ? '<p class="text-muted small">Nenhum agendamento neste turno.</p>' : '<p class="text-muted small mt-4">Todos os horários deste turno estão ocupados.</p>')
+                    }
+                </div>
+                <div class="card-footer text-end">
+                    <a href="/novo-agendamento.html?lab_id=${labSelecionadoId}&data=${dataFormatada}&turno=${turno}" class="btn btn-primary btn-sm btn-novo-agendamento-turno">
+                        <i class="bi bi-plus"></i> Novo Agendamento
+                    </a>
+                </div>
+            </div>`;
         }).join('');
+    }
+
+    // Função para abrir o modal de confirmação de exclusão
+    window.excluirAgendamento = function(id) {
+        agendamentoParaExcluirId = id;
+        confirmacaoModal.show();
+    }
+
+    // Função para confirmar e executar a exclusão
+    async function executarExclusao() {
+        if (!agendamentoParaExcluirId) return;
+
+        try {
+            await chamarAPI(`/agendamentos/${agendamentoParaExcluirId}`, 'DELETE');
+            exibirAlerta('Agendamento excluído com sucesso!', 'success');
+            agendamentoParaExcluirId = null;
+            confirmacaoModal.hide();
+            await carregarAgendaDiaria();
+        } catch (error) {
+            exibirAlerta(`Erro ao excluir agendamento: ${error.message}`, 'danger');
+        }
     }
 
     function adicionarListeners() {
@@ -197,6 +215,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 carregarAgendaDiaria();
             }
         });
+
+        const btnConfirma = document.getElementById('btnConfirmarExclusao');
+        if (btnConfirma) {
+            btnConfirma.addEventListener('click', executarExclusao);
+        }
 
         // Adicione aqui a lógica para os botões de navegação de data, se desejar.
     }


### PR DESCRIPTION
## Summary
- add confirmation modal HTML to agenda page
- rework daily agenda script to support deletion confirmation and hide available slot section when none exist

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6868703c732c8323825b660fa0891204