### PR TITLE
Add custom icon support to labs

### DIFF
--- a/src/models/laboratorio_turma.py
+++ b/src/models/laboratorio_turma.py
@@ -13,20 +13,24 @@ class Laboratorio(db.Model):
         data_atualizacao (datetime): Data da última atualização do registro
     """
     __tablename__ = 'laboratorios'
-    
+
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(50), nullable=False, unique=True)
+    # Novo campo para a classe de ícone do laboratório
+    classe_icone = db.Column(db.String(50), nullable=True, default='bi-box-seam')
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
     data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    
-    def __init__(self, nome):
+
+    def __init__(self, nome, classe_icone=None):
         """
         Inicializa um novo laboratório.
-        
+
         Args:
             nome (str): Nome do laboratório
+            classe_icone (str, optional): Classe CSS do ícone do laboratório
         """
         self.nome = nome
+        self.classe_icone = classe_icone or 'bi-box-seam'
     
     def to_dict(self):
         """
@@ -38,6 +42,7 @@ class Laboratorio(db.Model):
         return {
             'id': self.id,
             'nome': self.nome,
+            'classe_icone': self.classe_icone,
             'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
             'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None
         }

--- a/src/routes/laboratorio.py
+++ b/src/routes/laboratorio.py
@@ -49,10 +49,13 @@ def criar_laboratorio():
     # Verifica se já existe um laboratório com o mesmo nome
     if Laboratorio.query.filter_by(nome=data['nome']).first():
         return jsonify({'erro': 'Já existe um laboratório com este nome'}), 400
-    
+
     # Cria o laboratório
     try:
-        novo_laboratorio = Laboratorio(nome=data['nome'])
+        novo_laboratorio = Laboratorio(
+            nome=data['nome'],
+            classe_icone=data.get('classe_icone')
+        )
         db.session.add(novo_laboratorio)
         db.session.commit()
         return jsonify(novo_laboratorio.to_dict()), 201
@@ -87,6 +90,7 @@ def atualizar_laboratorio(id):
     # Atualiza o laboratório
     try:
         laboratorio.nome = data['nome']
+        laboratorio.classe_icone = data.get('classe_icone', laboratorio.classe_icone)
         db.session.commit()
         return jsonify(laboratorio.to_dict())
     except SQLAlchemyError as e:

--- a/src/static/js/agenda-diaria.js
+++ b/src/static/js/agenda-diaria.js
@@ -49,46 +49,41 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
+    // VERSÃO FINAL DA FUNÇÃO carregarLaboratorios
+
     async function carregarLaboratorios() {
         try {
-            laboratorios = await chamarAPI('/laboratorios');
+            const laboratorios = await chamarAPI('/laboratorios');
             const seletor = document.getElementById('seletor-laboratorios');
             if (seletor) {
                 seletor.innerHTML = laboratorios.map(lab => {
-                    let iconClass = 'bi-box-seam-fill'; // Ícone padrão para novos laboratórios
+                    let iconClass;
 
-                    // Lógica para escolher o ícone com base no nome
-                    switch (lab.nome.toLowerCase()) {
-                        case 'informática':
-                            iconClass = 'bi-pc-display';
-                            break;
-                        case 'soldagem':
-                            iconClass = 'bi-fire';
-                            break;
-                        case 'ajustagem mecanica e usinagem':
-                            iconClass = 'bi-gear-fill';
-                            break;
-                        // --- ÍCONES ATUALIZADOS ---
-                        case 'eletrica':
-                            iconClass = 'bi-lightning-charge-fill'; // Novo ícone
-                            break;
-                        case 'eletronica':
-                            iconClass = 'bi-cpu-fill'; // Novo ícone
-                            break;
-                        // --- FIM DA ATUALIZAÇÃO ---
-                        case 'laboratório 4.0':
-                            iconClass = 'bi-robot';
-                            break;
-                        case 'auditório':
-                            iconClass = 'bi-mic-fill';
-                            break;
+                    // --- NOVA LÓGICA INTELIGENTE ---
+                    // Passo 1: Tenta usar o ícone personalizado guardado na base de dados.
+                    if (lab.classe_icone && lab.classe_icone.startsWith('bi-')) {
+                        iconClass = lab.classe_icone;
+                    }
+                    // Passo 2 (Fallback): Se não houver ícone personalizado, usa a lógica de switch.
+                    else {
+                        switch (lab.nome.toLowerCase()) {
+                            case 'informática': iconClass = 'bi-pc-display'; break;
+                            case 'soldagem': iconClass = 'bi-fire'; break;
+                            case 'ajustagem mecanica e usinagem': iconClass = 'bi-gear-fill'; break;
+                            case 'eletrica': iconClass = 'bi-lightning-charge-fill'; break;
+                            case 'eletronica': iconClass = 'bi-cpu-fill'; break;
+                            case 'laboratório 4.0': iconClass = 'bi-robot'; break;
+                            case 'auditório': iconClass = 'bi-mic-fill'; break;
+                            // Passo 3 (Fallback final): Se não corresponder a nada, usa um ícone padrão.
+                            default: iconClass = 'bi-box-seam'; break;
+                        }
                     }
 
                     return `
-                    <div class="lab-icon" data-id="${lab.id}" title="${escapeHTML(lab.nome)}">
-                        <i class="bi ${iconClass}"></i>
-                        <span>${escapeHTML(lab.nome)}</span>
-                    </div>
+                        <div class="lab-icon" data-id="${lab.id}" title="${escapeHTML(lab.nome)}">
+                            <i class="bi ${iconClass}"></i>
+                            <span>${escapeHTML(lab.nome)}</span>
+                        </div>
                     `;
                 }).join('');
             }

--- a/src/static/laboratorios-turmas.html
+++ b/src/static/laboratorios-turmas.html
@@ -107,6 +107,13 @@
                                 <label for="nomeLaboratorio" class="form-label">Nome do Laboratório</label>
                                 <input type="text" class="form-control" id="nomeLaboratorio" placeholder="Ex: Lab 01" required>
                             </div>
+                            <div class="col-md-5">
+                                <label for="classeIconeLaboratorio" class="form-label">Classe do Ícone</label>
+                                <input type="text" class="form-control" id="classeIconeLaboratorio" placeholder="Ex: bi-robot">
+                                <small class="form-text text-muted">
+                                    Cole a classe do <a href="https://icons.getbootstrap.com/" target="_blank">Bootstrap Icons</a> aqui.
+                                </small>
+                            </div>
                             <div class="col-md-4 d-flex align-items-end">
                                 <button type="submit" class="btn btn-primary w-100" id="btnSalvarLaboratorio">
                                     <i class="bi bi-plus-circle me-2"></i>Adicionar
@@ -274,7 +281,7 @@
                                 <td>${lab.nome}</td>
                                 <td>${formatarData(lab.data_criacao)}</td>
                                 <td>
-                                    <button class="btn btn-sm btn-outline-primary me-1" onclick="editarLaboratorio(${lab.id}, '${lab.nome}')">
+                                    <button class="btn btn-sm btn-outline-primary me-1" onclick="editarLaboratorio(${lab.id}, '${lab.nome}', '${lab.classe_icone || ''}')">
                                         <i class="bi bi-pencil"></i>
                                     </button>
                                     <button class="btn btn-sm btn-outline-danger" onclick="confirmarExclusao('laboratorio', ${lab.id}, '${lab.nome}')">
@@ -335,6 +342,7 @@
             async function salvarLaboratorio() {
                 const id = document.getElementById('laboratorioId').value;
                 const nome = document.getElementById('nomeLaboratorio').value;
+                const classeIcone = document.getElementById('classeIconeLaboratorio').value;
                 
                 if (!nome) {
                     exibirAlerta('O nome do laboratório é obrigatório.', 'danger');
@@ -344,11 +352,11 @@
                 try {
                     if (id) {
                         // Atualização
-                        await chamarAPI(`/laboratorios/${id}`, 'PUT', { nome });
+                        await chamarAPI(`/laboratorios/${id}`, 'PUT', { nome, classe_icone: classeIcone });
                         exibirAlerta('Laboratório atualizado com sucesso!', 'success');
                     } else {
                         // Criação
-                        await chamarAPI('/laboratorios', 'POST', { nome });
+                        await chamarAPI('/laboratorios', 'POST', { nome, classe_icone: classeIcone });
                         exibirAlerta('Laboratório cadastrado com sucesso!', 'success');
                     }
                     
@@ -394,9 +402,10 @@
             }
             
             // Função para editar um laboratório
-            window.editarLaboratorio = function(id, nome) {
+            window.editarLaboratorio = function(id, nome, classe) {
                 document.getElementById('laboratorioId').value = id;
                 document.getElementById('nomeLaboratorio').value = nome;
+                document.getElementById('classeIconeLaboratorio').value = classe || '';
                 document.getElementById('btnSalvarLaboratorio').innerHTML = '<i class="bi bi-check-circle me-2"></i>Atualizar';
                 document.getElementById('nomeLaboratorio').focus();
             };


### PR DESCRIPTION
## Summary
- allow storing icon class in `Laboratorio`
- accept `classe_icone` in POST and PUT routes
- add field in `laboratorios-turmas.html` to set icon class
- send icon class when creating/updating labs and when editing
- show custom lab icons in agenda using new logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68693404b71c8323a0748da778c6e24e