### PR TITLE
Add startup script for Railway deployment

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Este script é executado pela plataforma de deploy (Railway) para iniciar a aplicação.
+
+# Saia imediatamente se um comando falhar
+set -e
+
+# 1. Aplicar as migrações da base de dados
+echo "A aplicar migrações da base de dados..."
+flask db upgrade
+
+# 2. Iniciar o servidor web Gunicorn
+# O Gunicorn irá escutar na porta fornecida pela variável de ambiente $PORT
+echo "A iniciar o servidor Gunicorn..."
+exec gunicorn src.main:app --bind 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- add `startup.sh` to run DB migrations and start Gunicorn
- make `startup.sh` executable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68693e50d4c0832384e727b0f82498fa