### PR TITLE
Fix startup command for Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN poetry install --no-root --without dev
 COPY ./src ./src
 
 # Expor a porta que o Gunicorn usará
-EXPOSE 8000
+EXPOSE 8080
 
 # Comando para iniciar a aplicação
-CMD ["poetry", "run", "gunicorn", "--bind", "0.0.0.0:8000", "src.main:create_app()"]
+CMD ["gunicorn", "src.main:app", "--bind", "0.0.0.0:8080"]

--- a/startup.sh
+++ b/startup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-echo "A aplicar migrações da base de dados..."
-flask db upgrade
-
-echo "A iniciar o servidor Gunicorn..."
-exec gunicorn src.main:app --bind 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- remove obsolete `startup.sh`
- update `Dockerfile` to start with `gunicorn` on port 8080

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68694fc980988323aceeb5e8b0035ef9