### PR TITLE
Implement empty state on calendar page

### DIFF
--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -83,6 +83,15 @@
                     <div class="spinner-border text-primary" style="width: 3rem; height: 3rem;" role="status"></div>
                     <p class="mt-2">Carregando agenda...</p>
                 </div>
+
+                <div id="empty-state-container" class="text-center p-5 border rounded bg-light" style="display: none;">
+                    <i class="bi bi-box-seam" style="font-size: 4rem; color: #6c757d;"></i>
+                    <h4 class="mt-3">Nenhum Laboratório Cadastrado</h4>
+                    <p class="text-muted">Para começar a usar a agenda diária, você precisa de cadastrar pelo menos um laboratório.</p>
+                    <a href="/laboratorios-turmas.html" class="btn btn-primary mt-3">
+                        <i class="bi bi-plus-lg"></i> Cadastrar Primeiro Laboratório
+                    </a>
+                </div>
                 
                 <div id="agenda-content" style="display: none;">
                     <h2 class="text-uppercase mb-4">AGENDA DIÁRIA DE LABORATÓRIOS</h2>

--- a/src/static/js/agenda-diaria.js
+++ b/src/static/js/agenda-diaria.js
@@ -28,24 +28,35 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Função de inicialização
     async function inicializarPagina() {
+        // Adiciona a referência ao novo elemento
+        const emptyStateEl = document.getElementById('empty-state-container');
+
+        // Esconde o conteúdo principal por padrão para evitar piscar na tela
+        contentEl.style.display = 'none';
+        emptyStateEl.style.display = 'none';
+        loadingEl.style.display = 'block';
+
         await carregarLaboratorios();
-        inicializarMiniCalendario();
-        adicionarListeners();
-        
+
+        // --- LÓGICA DE EXIBIÇÃO CORRIGIDA ---
         if (laboratorios.length > 0) {
+            // Se há laboratórios, mostra a interface da agenda
+            inicializarMiniCalendario();
+            adicionarListeners();
+
             const primeiroLabIcon = document.querySelector('.lab-icon');
-            if(primeiroLabIcon) {
+            if (primeiroLabIcon) {
                 labSelecionadoId = primeiroLabIcon.dataset.id;
                 primeiroLabIcon.classList.add('active');
             }
-            await carregarAgendaDiaria();
+            await atualizarVisualizacaoCompleta(dataSelecionada);
+
             loadingEl.style.display = 'none';
-            contentEl.style.display = 'block';
-            if (miniCalendar) {
-                miniCalendar.updateSize();
-            }
+            contentEl.style.display = 'block'; // Mostra a agenda
         } else {
-            loadingEl.innerHTML = '<p class="text-muted">Nenhum laboratório cadastrado.</p>';
+            // Se NÃO há laboratórios, mostra a mensagem de estado vazio
+            loadingEl.style.display = 'none';
+            emptyStateEl.style.display = 'block'; // Mostra o novo container
         }
     }
 


### PR DESCRIPTION
## Summary
- add missing empty state container to `calendario.html`
- update `inicializarPagina` in `agenda-diaria.js` to show empty state when there are no labs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68695a7edf508323aab18f437238365c