### PR TITLE
Fix ModuleNotFoundError by adding missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 redis
+Flask-JWT-Extended


### PR DESCRIPTION
## Summary
- ensure `Flask-JWT-Extended` is listed in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6869727de2bc83239ea66f4b0d01583b