### PR TITLE
Add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,11 @@
 redis
 Flask-JWT-Extended
+
+Flask
+Flask-SQLAlchemy
+Flask-Migrate
+Flask-Limiter
+gunicorn
+psycopg2-binary
+python-dotenv
+Flask-JWT-Extended


### PR DESCRIPTION
## Summary
- ensure Flask-related dependencies are present in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68697473e05c8323bd433e8f47276b0f