### PR TITLE
Fix missing auth dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "email-validator (==2.2.0)",
     "redis (==5.0.1)",
     "flask-limiter (==3.12)",
-    "flask-migrate (==4.0.5)"
+    "flask-migrate (==4.0.5)",
+    "flask-jwt-extended (==4.6.0)"
 ]
 
 [tool.poetry]
@@ -54,6 +55,7 @@ email-validator = "2.2.0"
 redis = "5.0.1"
 flask-limiter = "3.12"
 flask-migrate = "4.0.5"
+flask-jwt-extended = "4.6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.4.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 redis
-Flask-JWT-Extended
+Flask-JWT-Extended==4.6.0
 
 Flask
 Flask-SQLAlchemy
@@ -8,4 +8,3 @@ Flask-Limiter
 gunicorn
 psycopg2-binary
 python-dotenv
-Flask-JWT-Extended


### PR DESCRIPTION
## Summary
- include `flask-jwt-extended` in the dependency lists
- remove duplicate entry and pin version in requirements.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68697bd0ded883238dccece52f9ed1c2